### PR TITLE
Migrate UI to Skeleton UI with Tailwind CSS 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,21 @@
     "@tauri-apps/plugin-opener": "^2"
   },
   "devDependencies": {
+    "@skeletonlabs/skeleton": "4.10.0",
+    "@skeletonlabs/skeleton-svelte": "4.9.0",
     "@sveltejs/adapter-static": "^3.0.6",
     "@sveltejs/kit": "^2.9.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@tailwindcss/vite": "^4.1.18",
+    "@tauri-apps/cli": "^2",
     "@wdio/cli": "^9.19.0",
     "@wdio/local-runner": "^9.19.0",
     "@wdio/mocha-framework": "^9.19.0",
     "@wdio/spec-reporter": "^9.19.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
+    "tailwindcss": "4.1.18",
     "typescript": "~5.6.2",
-    "vite": "^6.0.3",
-    "@tauri-apps/cli": "^2"
+    "vite": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,15 +15,24 @@ importers:
         specifier: ^2
         version: 2.5.2
     devDependencies:
+      '@skeletonlabs/skeleton':
+        specifier: 4.10.0
+        version: 4.10.0(tailwindcss@4.1.18)
+      '@skeletonlabs/skeleton-svelte':
+        specifier: 4.9.0
+        version: 4.9.0(svelte@5.46.1)
       '@sveltejs/adapter-static':
         specifier: ^3.0.6
-        version: 3.0.10(@sveltejs/kit@2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))
+        version: 3.0.10(@sveltejs/kit@2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))
       '@sveltejs/kit':
         specifier: ^2.9.0
-        version: 2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))
+        version: 2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))
+        version: 5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.9.6
@@ -45,12 +54,15 @@ importers:
       svelte-check:
         specifier: ^4.0.0
         version: 4.3.5(picomatch@4.0.3)(svelte@5.46.1)(typescript@5.6.3)
+      tailwindcss:
+        specifier: 4.1.18
+        version: 4.1.18
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
       vite:
         specifier: ^6.0.3
-        version: 6.4.1(@types/node@25.0.3)(tsx@4.21.0)
+        version: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
 packages:
 
@@ -374,6 +386,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
@@ -507,6 +528,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@internationalized/date@3.10.1':
+    resolution: {integrity: sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -687,6 +711,19 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@skeletonlabs/skeleton-common@4.9.0':
+    resolution: {integrity: sha512-uutuaNgmmagaTtDcr/sl5VT1gUYwPjonaKW6Hxf5NTG0bYNFTPatsDFuvxDiXo4lSvS8bHNu07r0wjQrlUkXaA==}
+
+  '@skeletonlabs/skeleton-svelte@4.9.0':
+    resolution: {integrity: sha512-PrOJrKXAYnGnteQMD5Sk+xgF73d2jSut+N6uwEmrSQcFOtkQZX2iUGyrOG66za8oKVKhtPj/jLGU2QaoNuhSQA==}
+    peerDependencies:
+      svelte: ^5.29.0
+
+  '@skeletonlabs/skeleton@4.10.0':
+    resolution: {integrity: sha512-wmawxvCdKgKP1CcvKFmHefdzP/9UoV4xVq/itjoOcQ6CT/JxVqOwvOvqdEuND3x5GYb0QEX0yLgeQOqAQvpjQw==}
+    peerDependencies:
+      tailwindcss: ^4.0.0
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -727,6 +764,99 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
       vite: ^6.0.0
+
+  '@swc/helpers@0.5.18':
+    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
+
+  '@tailwindcss/node@4.1.18':
+    resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    resolution: {integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    resolution: {integrity: sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    resolution: {integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    resolution: {integrity: sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    resolution: {integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    resolution: {integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    resolution: {integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    resolution: {integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.18':
+    resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/vite@4.1.18':
+    resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7
 
   '@tauri-apps/api@2.9.1':
     resolution: {integrity: sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==}
@@ -933,6 +1063,153 @@ packages:
   '@wdio/xvfb@9.20.0':
     resolution: {integrity: sha512-shllZH9CsLiZqTXkqBTJrwi6k/ajBE7/78fQgvafMUIQU1Hpb2RdsmydKfPFZ5NDoA+LNm67PD2cPkvkXy4pSw==}
     engines: {node: '>=18'}
+
+  '@zag-js/accordion@1.31.1':
+    resolution: {integrity: sha512-3sGi4EZpGBz/O1IVkk9dzzWzP5vVVOj4Li6C+jHOnrgaWPouA/mBTP5L9HEL8qtFsECFZwpNo486eqiCmeHoGw==}
+
+  '@zag-js/anatomy@1.31.1':
+    resolution: {integrity: sha512-BhIhf3Q0tRA0Jugd7AJfUBzeAb/iATBsw7KyYThMGcPWmrWssL7KWr5AB6RufzGKU7+DCb1QEhlqd4NSOJaYxQ==}
+
+  '@zag-js/aria-hidden@1.31.1':
+    resolution: {integrity: sha512-SoNt4S2LkHNWPglQczWN0E5vAV15MT1GoK9MksZzbkMhl+pkDTdLytpXsQ1IgalC1YUng0XNps/Wt6P3uDuzTA==}
+
+  '@zag-js/auto-resize@1.31.1':
+    resolution: {integrity: sha512-qzWHibjBekSmFweG+EWY8g0lRzKtok7o9XtQ+JFlOu3s6x4D02z2YDzjDdfSLmS7j0NxISnwQkinWiDAZEYHog==}
+
+  '@zag-js/avatar@1.31.1':
+    resolution: {integrity: sha512-Grosi2hRn4wfDYlPd8l+d4GCIFMsoj6ZFqii+1k14AqTDiCUJ/J0jCvOrRHkvkpEqektjuSD7e/GCX+yawqkuQ==}
+
+  '@zag-js/carousel@1.31.1':
+    resolution: {integrity: sha512-228Ol86G/lg8crcomy5cALkUYdOHCHcvJnSOQzeUj80JNjlELzrjBpaAj4lx8dZocfwou2Sg4NyZJ+mISSc+Dg==}
+
+  '@zag-js/collapsible@1.31.1':
+    resolution: {integrity: sha512-eCC5G6bBZUwF8z2XULQXUNRxqte9I2Sv+WJ2brycPn1a68uYD76RzFBmLQ2er95VbshUdeo8nRuX8MooAFuYzg==}
+
+  '@zag-js/collection@1.31.1':
+    resolution: {integrity: sha512-ecpfyfCj8Y0/GUPuHYsLxexIrx10VuR3Wd0H+lamcki3lYgQxZrpLRFMwgTqmI/m7t3zhm5QeEvMUJ1H14YMLA==}
+
+  '@zag-js/combobox@1.31.1':
+    resolution: {integrity: sha512-IT0getSAGzngdRL20iX/iAh2d7DzVoMDDppOsOFBG2owKAgLpj8uLvUhy+lcrm6N8yxYOya89D6Aef7V5KdwlQ==}
+
+  '@zag-js/core@1.31.1':
+    resolution: {integrity: sha512-RaMJeqtjxG6k7iFD3WQnlyFJVT3yfQN+pJygAHH37GsMtiNzQQJOoesjb0LV9T27jwMXeNUzrh3MSDr1/0yVcQ==}
+
+  '@zag-js/date-picker@1.31.1':
+    resolution: {integrity: sha512-AOWN/IskGidVQt5g+uE9cILqJBTclE6OG1GC9WSWuyP/y4F+PdP/781SgYpYCZg/6pMGbL01PFKKb7xOOCeZAg==}
+    peerDependencies:
+      '@internationalized/date': '>=3.0.0'
+
+  '@zag-js/date-utils@1.31.1':
+    resolution: {integrity: sha512-+Aq9g/rqLeiRmnazgdZMc59gAxqxbw3GGy8AngrtNipgRtMhPlzGa3S4Qsq1yau6OKaHZ13uckUS+MhLNbBY+Q==}
+    peerDependencies:
+      '@internationalized/date': '>=3.0.0'
+
+  '@zag-js/dialog@1.31.1':
+    resolution: {integrity: sha512-iaWlYQ6TYoVjM/X5+UZVZzKiMboE50GnEzGUpbhbeRNRiLqSu5dODSFzior1G4kde/ns5eN+BTf/Tm6AT4N2og==}
+
+  '@zag-js/dismissable@1.31.1':
+    resolution: {integrity: sha512-jCdJwQmEkG6PlrN13fUk2l7ZclSu54FZwmT4xOtQpEbaiAiESm5KI5oyFh5jDPY47Goa28UJkEjWXVgKXKWb0g==}
+
+  '@zag-js/dom-query@1.31.1':
+    resolution: {integrity: sha512-2tCZLwSfoXm62gwl0neiAN6u5VnzUhy5wHtKbX+klqGFatnca3Bm++H9+4PHMrwUWRbPg3H5N151lKFEOQhBfQ==}
+
+  '@zag-js/file-upload@1.31.1':
+    resolution: {integrity: sha512-cp7qMiXKrIcTfDamOz9wlnJLeBF8gucTI7Y+iKaP+hiIW+OG254GElfQiqXNDad3HUmD+Dt8Tx6uAzL/mw3sbQ==}
+
+  '@zag-js/file-utils@1.31.1':
+    resolution: {integrity: sha512-MDDz52IdPh/mPUYrqUXvh7qDckJHs+mt5gjfx0N89qh2JNXuRU14zPotOKTzIKM4o+HFZkAT6BAfMpr9CX/0ug==}
+
+  '@zag-js/floating-panel@1.31.1':
+    resolution: {integrity: sha512-Pjgd/wjdglZ90dtq/LC4o5sc6w0m+RehhPmJcIzq9T+E/Xrb6qrhf06QhxB9LwSj4DG/gIv87gmD2qF1VH7cRQ==}
+
+  '@zag-js/focus-trap@1.31.1':
+    resolution: {integrity: sha512-omgUhAz1r81pYAujqYIIavdTKJzDRExioSiqhnx/xq10a6Q/xavMFflq8w7edMc9JHkTOnr9E5qh9abCVJjhpQ==}
+
+  '@zag-js/focus-visible@1.31.1':
+    resolution: {integrity: sha512-GC59A3yd7tj8aKhzvhrM+CEZZraXm5y/SpfIjz1J7kGV6eeXbUtjkbe75g99Ve8iJYfQVQlAj2GyN3oniHc5Zw==}
+
+  '@zag-js/i18n-utils@1.31.1':
+    resolution: {integrity: sha512-SARkFuo1+Q0WcNv4jqvxp5hjCOqu/gBa7p6BTh7v5Bo00QhKRM/bCvVt0EB6V+h2oejrZfkwZ0MwbpQiL6L2aQ==}
+
+  '@zag-js/interact-outside@1.31.1':
+    resolution: {integrity: sha512-oxBAlBqcatlxGUmhwUCRYTADIBrVoyxM1YrFzR1R8jhvVR/QCaxoLAyKwcA3mWXlZ8+NlXb7n5ELE11BZb/rEg==}
+
+  '@zag-js/listbox@1.31.1':
+    resolution: {integrity: sha512-LcTIr4I9eN4MR1nSRfQfseWgj4ybOXXAY2o5dBpEBL67dnCSX3swNb/4LQO+ebj077BViQb66pBb1KSoeHGkEQ==}
+
+  '@zag-js/live-region@1.31.1':
+    resolution: {integrity: sha512-RBx8jk1dgvkEUuFs77SBZn0WwvEkeZgVawVu6XUAy4ENfhP0D/qkvwNk+Els8InKmr1gWKajD7sh+g8M40Ex6A==}
+
+  '@zag-js/menu@1.31.1':
+    resolution: {integrity: sha512-eJPRM8tlauRTsAoJXchDBzMzL2RhXYSHmHak2IJCDMApCV51p0MqGYP8Er3DbMSQTPUFuTq779uUIarDqW+zmA==}
+
+  '@zag-js/pagination@1.31.1':
+    resolution: {integrity: sha512-icW6FNzIKNz7iXU+prlQWpMFJedDrhmCKzzI39SY+dv5g1Gnrlc0b44PxvNl5PWFLSkB5KBT/R1WCqd8Kh4cCA==}
+
+  '@zag-js/popover@1.31.1':
+    resolution: {integrity: sha512-uCFJP3DFBkEBAre6lgGLw2xWS2ZIuT/DLeajIXb+8BmC9KCF0wY4c9qojx9F3rGMJQxcGl+WUoXENkOvkTaVhQ==}
+
+  '@zag-js/popper@1.31.1':
+    resolution: {integrity: sha512-wLXcEqzn9MK1rGbsgnDH26o5ZWqR4oeb6ZepKKy0gcuJl/1S5/dr1VBvxJNMZlf9d6etvYklG5LRnIVkXCbrjA==}
+
+  '@zag-js/progress@1.31.1':
+    resolution: {integrity: sha512-f9lIDHCRcFAG14LVEKOAPTdqPzphwIIraC6fTr9AwmNlYI6/qFDkz3jOlYVSyk5VsJAIFM/777x/CdqjliiOqg==}
+
+  '@zag-js/radio-group@1.31.1':
+    resolution: {integrity: sha512-OfKIdEtSG0EuHM+cFVqcR+04yzZmcDRgG3j0QhoJsyS1my63ZHbwC2HNAtfPFh4U4sJx9yUexwSzPGZ6pOzIdw==}
+
+  '@zag-js/rating-group@1.31.1':
+    resolution: {integrity: sha512-BkQUglKm4a+KXYPACYvIvBJSuEyzV0YQqjjiucwJ5UiOlK72C66VBvyGN+DqJRDnkU1K5azt6E1Ja5ANk3fgsg==}
+
+  '@zag-js/rect-utils@1.31.1':
+    resolution: {integrity: sha512-lBFheAnz8+3aGDFjqlkw0Iew/F03lFjiIf26hkkcFSZu0ltNZUMG/X3XLHUnHxdfbdBguc8ons6mr2MkVvisng==}
+
+  '@zag-js/remove-scroll@1.31.1':
+    resolution: {integrity: sha512-gVVJuFKaCjo652RmajYmkjXKgjJWLQ5ZhZLTaLUKWM1mAarvlqnLui8jrHEHLxqpfsjQylfdhJKkWmyF8NAgTA==}
+
+  '@zag-js/scroll-snap@1.31.1':
+    resolution: {integrity: sha512-YWsfhcQqiffu2X9HuB0fMnEQAu6rEOfGcvQYinvB6pjWPOvIJGxGMi/dYyy21XQDNJ9K1IcWRIo/yuaajoJyQQ==}
+
+  '@zag-js/slider@1.31.1':
+    resolution: {integrity: sha512-FILbLTMd3BnyclZ28+ippfyqzYPGK60qZapxtTERmWDC75Okf8AFnTCQf84Y8jRmBKCS1yhjF+IOtkFAENeB6w==}
+
+  '@zag-js/steps@1.31.1':
+    resolution: {integrity: sha512-KsBH38V3tH9/q8CDgx4sUSXLYwFdcp1crZy8hTIcN0RUiZ55PmqYKkN2znzBjTbaCW9yhP8kXsbuo2s8OIU5lQ==}
+
+  '@zag-js/store@1.31.1':
+    resolution: {integrity: sha512-d5ZTRciTuXOGQ3nML15kQLaTiR1wJPxT1Fu1nN659X6Rl8DPtubYaRCZ3RCk9Kyiyg2z5HxeVqDswaDvGbM9Rg==}
+
+  '@zag-js/svelte@1.31.1':
+    resolution: {integrity: sha512-yj9ZzXHk4YV+zcLHypfqcA8BkP5043V58AZ3Hu3WMVczF4/GcmbHn4/nWNK+6j7M+BLCNEAx460SOZovSNemvw==}
+    peerDependencies:
+      svelte: '>=5'
+
+  '@zag-js/switch@1.31.1':
+    resolution: {integrity: sha512-Jii3OSqSa9sQux+hvSRvp9dirzUF09+PAjrLjCQs+BT08EZ0XqeGvVzM0Wqf9LFy07HdLZntai3IUaXLF6byBw==}
+
+  '@zag-js/tabs@1.31.1':
+    resolution: {integrity: sha512-QBq4ngpBNMNEI7Wuaq8llwHOqgcVbNHHEDC5zHg60Bf7MY5ltP8wSq6Kldu0zZRVwrLzanYoMELDUyf9H0vtnw==}
+
+  '@zag-js/tags-input@1.31.1':
+    resolution: {integrity: sha512-V4lJe/aMIs7WVoXYfszU6E3iARLLRQFMiycu76/slb8NWJiLrkSIaMQ4FAe2pqkodgCWXA83tuaeAZRq7ouTFg==}
+
+  '@zag-js/toast@1.31.1':
+    resolution: {integrity: sha512-MueHEei9ol3H6tWBruLxF7yEUpV3vsJ8brTQVRRtPr/6pqBs5kGzfL4YskhQ2tiwO6egay8YrkbaS3xJfpKt4w==}
+
+  '@zag-js/toggle-group@1.31.1':
+    resolution: {integrity: sha512-Mojc7mex01/gvwXfrUIIThzT7HOktZoMge9rrb6+P7rQX7ulyNXYPjQrW2tay+t54GOJ3xODo9dU7PpRzXeHbw==}
+
+  '@zag-js/tooltip@1.31.1':
+    resolution: {integrity: sha512-pWEU5XhEPpnyl2VLrGJlyjj7+p+X0UX3Fld+WGhc/hCaWiuW2ZzD/ewDRhSOZu4/TzAO3axrPqG1YhW4fhogKQ==}
+
+  '@zag-js/tree-view@1.31.1':
+    resolution: {integrity: sha512-Q+VSQz7X1XR8gT7ICWXlQOJIvzTWw/9BlF7B073UpEgAKRFlD11FmERka5y/BYqj8uE0vazcbSEA3Vc2dgCMJA==}
+
+  '@zag-js/types@1.31.1':
+    resolution: {integrity: sha512-mKw5DoeBjFykfUHv3ifCRjcogFTqp0aCCsmqQMfnf+J/mg2aXpAx76AXT1PYXAVVhxdP6qGXNd0mOQZDVrIlSQ==}
+
+  '@zag-js/utils@1.31.1':
+    resolution: {integrity: sha512-KLm0pmOtf4ydALbaVLboL7W98TDVxwVVLvSuvtRgV53XTjlsVopTRA5/Xmzq2NhWujDZAXv7bRV603NDgDcjSw==}
 
   '@zip.js/zip.js@2.8.14':
     resolution: {integrity: sha512-BZ7OyJLA5cjYwf2jVjvZCK10swzIc6sDOLpkPjJXfXgx/IHF5y61PyL3Ko5/q3bUU5GvIhk6tzKDUcDJ7rhzbg==}
@@ -1208,6 +1485,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
@@ -1247,6 +1527,10 @@ packages:
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   devalue@5.6.1:
     resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
@@ -1307,6 +1591,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enhanced-resolve@5.18.4:
+    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+    engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1668,6 +1956,10 @@ packages:
     resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1692,6 +1984,76 @@ packages:
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  lightningcss-android-arm64@1.30.2:
+    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.30.2:
+    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.2:
+    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.2:
+    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.2:
+    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.2:
+    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
 
   lines-and-columns@2.0.4:
     resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
@@ -1945,6 +2307,9 @@ packages:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
     engines: {node: '>= 14'}
 
+  proxy-compare@3.0.1:
+    resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -2179,6 +2544,13 @@ packages:
   svelte@5.46.1:
     resolution: {integrity: sha512-ynjfCHD3nP2el70kN5Pmg37sSi0EjOm9FgHYQdC4giWG/hzO3AatzXXJJgP305uIhGQxSufJLuYWtkY8uK/8RA==}
     engines: {node: '>=18'}
+
+  tailwindcss@4.1.18:
+    resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
+
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
 
   tar-fs@3.1.1:
     resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
@@ -2599,6 +2971,17 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
+  '@floating-ui/core@1.7.4':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.4
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@inquirer/ansi@1.0.2': {}
 
   '@inquirer/checkbox@4.3.2(@types/node@25.0.3)':
@@ -2723,6 +3106,10 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@25.0.3)':
     optionalDependencies:
       '@types/node': 25.0.3
+
+  '@internationalized/date@3.10.1':
+    dependencies:
+      '@swc/helpers': 0.5.18
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2875,21 +3262,60 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@skeletonlabs/skeleton-common@4.9.0': {}
+
+  '@skeletonlabs/skeleton-svelte@4.9.0(svelte@5.46.1)':
+    dependencies:
+      '@internationalized/date': 3.10.1
+      '@skeletonlabs/skeleton-common': 4.9.0
+      '@zag-js/accordion': 1.31.1
+      '@zag-js/avatar': 1.31.1
+      '@zag-js/carousel': 1.31.1
+      '@zag-js/collapsible': 1.31.1
+      '@zag-js/collection': 1.31.1
+      '@zag-js/combobox': 1.31.1
+      '@zag-js/date-picker': 1.31.1(@internationalized/date@3.10.1)
+      '@zag-js/dialog': 1.31.1
+      '@zag-js/file-upload': 1.31.1
+      '@zag-js/floating-panel': 1.31.1
+      '@zag-js/listbox': 1.31.1
+      '@zag-js/menu': 1.31.1
+      '@zag-js/pagination': 1.31.1
+      '@zag-js/popover': 1.31.1
+      '@zag-js/progress': 1.31.1
+      '@zag-js/radio-group': 1.31.1
+      '@zag-js/rating-group': 1.31.1
+      '@zag-js/slider': 1.31.1
+      '@zag-js/steps': 1.31.1
+      '@zag-js/svelte': 1.31.1(svelte@5.46.1)
+      '@zag-js/switch': 1.31.1
+      '@zag-js/tabs': 1.31.1
+      '@zag-js/tags-input': 1.31.1
+      '@zag-js/toast': 1.31.1
+      '@zag-js/toggle-group': 1.31.1
+      '@zag-js/tooltip': 1.31.1
+      '@zag-js/tree-view': 1.31.1
+      svelte: 5.46.1
+
+  '@skeletonlabs/skeleton@4.10.0(tailwindcss@4.1.18)':
+    dependencies:
+      tailwindcss: 4.1.18
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))':
     dependencies:
-      '@sveltejs/kit': 2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))
+      '@sveltejs/kit': 2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
 
-  '@sveltejs/kit@2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))':
+  '@sveltejs/kit@2.49.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -2902,29 +3328,101 @@ snapshots:
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
       svelte: 5.46.1
-      vite: 6.4.1(@types/node@25.0.3)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       debug: 4.4.3(supports-color@8.1.1)
       svelte: 5.46.1
-      vite: 6.4.1(@types/node@25.0.3)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)))(svelte@5.46.1)(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       debug: 4.4.3(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.46.1
-      vite: 6.4.1(@types/node@25.0.3)(tsx@4.21.0)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0))
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
     transitivePeerDependencies:
       - supports-color
+
+  '@swc/helpers@0.5.18':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tailwindcss/node@4.1.18':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.18.4
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.18
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.18':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-x64': 4.1.18
+      '@tailwindcss/oxide-freebsd-x64': 4.1.18
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.18
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.18
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.18
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
+
+  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      tailwindcss: 4.1.18
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@tauri-apps/api@2.9.1': {}
 
@@ -3224,6 +3722,333 @@ snapshots:
     dependencies:
       '@wdio/logger': 9.18.0
 
+  '@zag-js/accordion@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/anatomy@1.31.1': {}
+
+  '@zag-js/aria-hidden@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+
+  '@zag-js/auto-resize@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+
+  '@zag-js/avatar@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/carousel@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/scroll-snap': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/collapsible@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/collection@1.31.1':
+    dependencies:
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/combobox@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/aria-hidden': 1.31.1
+      '@zag-js/collection': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dismissable': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/popper': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/core@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/date-picker@1.31.1(@internationalized/date@3.10.1)':
+    dependencies:
+      '@internationalized/date': 3.10.1
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/date-utils': 1.31.1(@internationalized/date@3.10.1)
+      '@zag-js/dismissable': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/live-region': 1.31.1
+      '@zag-js/popper': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/date-utils@1.31.1(@internationalized/date@3.10.1)':
+    dependencies:
+      '@internationalized/date': 3.10.1
+
+  '@zag-js/dialog@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/aria-hidden': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dismissable': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/focus-trap': 1.31.1
+      '@zag-js/remove-scroll': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/dismissable@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/interact-outside': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/dom-query@1.31.1':
+    dependencies:
+      '@zag-js/types': 1.31.1
+
+  '@zag-js/file-upload@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/file-utils': 1.31.1
+      '@zag-js/i18n-utils': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/file-utils@1.31.1':
+    dependencies:
+      '@zag-js/i18n-utils': 1.31.1
+
+  '@zag-js/floating-panel@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/popper': 1.31.1
+      '@zag-js/rect-utils': 1.31.1
+      '@zag-js/store': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/focus-trap@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+
+  '@zag-js/focus-visible@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+
+  '@zag-js/i18n-utils@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+
+  '@zag-js/interact-outside@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/listbox@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/collection': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/focus-visible': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/live-region@1.31.1': {}
+
+  '@zag-js/menu@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dismissable': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/popper': 1.31.1
+      '@zag-js/rect-utils': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/pagination@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/popover@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/aria-hidden': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dismissable': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/focus-trap': 1.31.1
+      '@zag-js/popper': 1.31.1
+      '@zag-js/remove-scroll': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/popper@1.31.1':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/progress@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/radio-group@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/focus-visible': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/rating-group@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/rect-utils@1.31.1': {}
+
+  '@zag-js/remove-scroll@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+
+  '@zag-js/scroll-snap@1.31.1':
+    dependencies:
+      '@zag-js/dom-query': 1.31.1
+
+  '@zag-js/slider@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/steps@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/store@1.31.1':
+    dependencies:
+      proxy-compare: 3.0.1
+
+  '@zag-js/svelte@1.31.1(svelte@5.46.1)':
+    dependencies:
+      '@zag-js/core': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+      svelte: 5.46.1
+
+  '@zag-js/switch@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/focus-visible': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/tabs@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/tags-input@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/auto-resize': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/interact-outside': 1.31.1
+      '@zag-js/live-region': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/toast@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dismissable': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/toggle-group@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/tooltip@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/focus-visible': 1.31.1
+      '@zag-js/popper': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/tree-view@1.31.1':
+    dependencies:
+      '@zag-js/anatomy': 1.31.1
+      '@zag-js/collection': 1.31.1
+      '@zag-js/core': 1.31.1
+      '@zag-js/dom-query': 1.31.1
+      '@zag-js/types': 1.31.1
+      '@zag-js/utils': 1.31.1
+
+  '@zag-js/types@1.31.1':
+    dependencies:
+      csstype: 3.2.3
+
+  '@zag-js/utils@1.31.1': {}
+
   '@zip.js/zip.js@2.8.14': {}
 
   abort-controller@3.0.0:
@@ -3503,6 +4328,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  csstype@3.2.3: {}
+
   data-uri-to-buffer@6.0.2: {}
 
   debug@4.4.3(supports-color@8.1.1):
@@ -3531,6 +4358,8 @@ snapshots:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
+
+  detect-libc@2.1.2: {}
 
   devalue@5.6.1: {}
 
@@ -3600,6 +4429,11 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  enhanced-resolve@5.18.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
 
   entities@4.5.0: {}
 
@@ -4025,6 +4859,8 @@ snapshots:
       graceful-fs: 4.2.11
       picomatch: 4.0.3
 
+  jiti@2.6.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -4049,6 +4885,55 @@ snapshots:
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
+
+  lightningcss-android-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.2:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss@1.30.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.30.2
+      lightningcss-darwin-arm64: 1.30.2
+      lightningcss-darwin-x64: 1.30.2
+      lightningcss-freebsd-x64: 1.30.2
+      lightningcss-linux-arm-gnueabihf: 1.30.2
+      lightningcss-linux-arm64-gnu: 1.30.2
+      lightningcss-linux-arm64-musl: 1.30.2
+      lightningcss-linux-x64-gnu: 1.30.2
+      lightningcss-linux-x64-musl: 1.30.2
+      lightningcss-win32-arm64-msvc: 1.30.2
+      lightningcss-win32-x64-msvc: 1.30.2
 
   lines-and-columns@2.0.4: {}
 
@@ -4304,6 +5189,8 @@ snapshots:
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
+
+  proxy-compare@3.0.1: {}
 
   proxy-from-env@1.1.0: {}
 
@@ -4582,6 +5469,10 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
+  tailwindcss@4.1.18: {}
+
+  tapable@2.3.0: {}
+
   tar-fs@3.1.1:
     dependencies:
       pump: 3.0.3
@@ -4663,7 +5554,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0):
+  vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4674,11 +5565,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.0.3
       fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
       tsx: 4.21.0
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@25.0.3)(tsx@4.21.0)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.0.3)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   wait-port@1.1.0:
     dependencies:

--- a/src/app.css
+++ b/src/app.css
@@ -1,156 +1,52 @@
-/* Global styles for Potasko */
+@import 'tailwindcss';
 
-:root {
-  /* Responsive breakpoints */
-  --mobile-breakpoint: 768px;
-  --touch-target-min: 44px;
+/* Configure dark mode to use .dark class (Tailwind selector strategy) */
+@variant dark (&:where(.dark, .dark *));
 
-  /* Colors - Light mode */
-  --bg-primary: #ffffff;
-  --bg-secondary: #f9fafb;
-  --bg-hover: #f3f4f6;
-  --bg-selected: #e5e7eb;
-  --text-primary: #111827;
-  --text-secondary: #6b7280;
-  --border-color: #e5e7eb;
-  --accent-color: #3b82f6;
-  --error-color: #dc2626;
+@import '@skeletonlabs/skeleton';
+@import '@skeletonlabs/skeleton-svelte';
 
-  /* Priority colors - Light mode */
-  --priority-high-bg: #fee2e2;
-  --priority-high-text: #dc2626;
-  --priority-medium-bg: #fef3c7;
-  --priority-medium-text: #d97706;
-  --priority-low-bg: #dbeafe;
-  --priority-low-text: #2563eb;
+/* Import all available Skeleton themes (keep in sync with AVAILABLE_THEMES in theme.svelte.ts) */
+@import '@skeletonlabs/skeleton/themes/catppuccin';
+@import '@skeletonlabs/skeleton/themes/cerberus';
+@import '@skeletonlabs/skeleton/themes/concord';
+@import '@skeletonlabs/skeleton/themes/crimson';
+@import '@skeletonlabs/skeleton/themes/fennec';
+@import '@skeletonlabs/skeleton/themes/hamlindigo';
+@import '@skeletonlabs/skeleton/themes/legacy';
+@import '@skeletonlabs/skeleton/themes/mint';
+@import '@skeletonlabs/skeleton/themes/modern';
+@import '@skeletonlabs/skeleton/themes/mona';
+@import '@skeletonlabs/skeleton/themes/nosh';
+@import '@skeletonlabs/skeleton/themes/nouveau';
+@import '@skeletonlabs/skeleton/themes/pine';
+@import '@skeletonlabs/skeleton/themes/reign';
+@import '@skeletonlabs/skeleton/themes/rocket';
+@import '@skeletonlabs/skeleton/themes/rose';
+@import '@skeletonlabs/skeleton/themes/sahara';
+@import '@skeletonlabs/skeleton/themes/seafoam';
+@import '@skeletonlabs/skeleton/themes/terminus';
+@import '@skeletonlabs/skeleton/themes/vintage';
+@import '@skeletonlabs/skeleton/themes/vox';
+@import '@skeletonlabs/skeleton/themes/wintry';
 
-  /* Typography */
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  color: var(--text-primary);
-  background-color: var(--bg-primary);
-
-  /* Rendering */
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
+/* Safe area insets for mobile */
+@layer base {
   :root {
-    --bg-primary: #1f2937;
-    --bg-secondary: #111827;
-    --bg-hover: #374151;
-    --bg-selected: #4b5563;
-    --text-primary: #f9fafb;
-    --text-secondary: #9ca3af;
-    --border-color: #374151;
-    --accent-color: #60a5fa;
-    --error-color: #f87171;
+    --safe-area-top: env(safe-area-inset-top, 0);
+    --safe-area-bottom: env(safe-area-inset-bottom, 0);
+  }
 
-    /* Priority colors - Dark mode */
-    --priority-high-bg: #7f1d1d;
-    --priority-high-text: #fca5a5;
-    --priority-medium-bg: #78350f;
-    --priority-medium-text: #fcd34d;
-    --priority-low-bg: #1e3a5f;
-    --priority-low-text: #93c5fd;
+  html, body {
+    height: 100%;
+  }
+
+  body {
+    overflow: hidden;
   }
 }
 
-/* Reset */
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
-html, body {
-  height: 100%;
-}
-
-body {
-  overflow: hidden;
-}
-
-/* Mobile drawer backdrop */
-.backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 99;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-}
-
-.backdrop.visible {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-/* Mobile header */
-.mobile-header {
-  display: none;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  padding-top: calc(0.75rem + env(safe-area-inset-top, 0));
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
-}
-
-.mobile-header h1 {
-  font-size: 1.125rem;
-  font-weight: 600;
-  margin: 0;
-}
-
-.hamburger-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--touch-target-min);
-  height: var(--touch-target-min);
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--text-primary);
-  border-radius: 8px;
-}
-
-.hamburger-btn:hover {
-  background: var(--bg-hover);
-}
-
-.hamburger-btn svg {
-  width: 24px;
-  height: 24px;
-}
-
-@media (max-width: 768px) {
-  .mobile-header {
-    display: flex;
-  }
-
-  /* Safe area padding for mobile devices */
-  .safe-area-bottom {
-    padding-bottom: env(safe-area-inset-bottom, 0);
-  }
-}
-
-/* Focus styles */
-:focus-visible {
-  outline: 2px solid var(--accent-color);
-  outline-offset: 2px;
-}
-
-/* Scrollbar styling */
+/* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -161,16 +57,20 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-color);
+  background: rgb(var(--color-surface-400));
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--text-secondary);
+  background: rgb(var(--color-surface-500));
 }
 
-/* Selection */
-::selection {
-  background: var(--accent-color);
-  color: white;
+/* Spin animation for sync indicators */
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.animate-spin {
+  animation: spin 1s linear infinite;
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="cerberus">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/src/lib/components/AccountForm.svelte
+++ b/src/lib/components/AccountForm.svelte
@@ -126,53 +126,57 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<form class="account-form" onsubmit={handleSubmit}>
-  <h3>{isEditing ? 'Edit Account' : 'Add CalDAV Account'}</h3>
+<form class="card flex flex-col gap-4 p-6 bg-surface-100-900 rounded-lg" onsubmit={handleSubmit}>
+  <h3 class="m-0 mb-2 text-lg font-semibold">{isEditing ? 'Edit Account' : 'Add CalDAV Account'}</h3>
 
-  <label class="form-field">
-    <span>Account Name</span>
+  <label class="flex flex-col gap-1.5">
+    <span class="text-sm text-surface-500">Account Name</span>
     <input
       type="text"
+      class="input"
       bind:value={name}
       placeholder="e.g., Work, Personal"
       disabled={saving}
     />
   </label>
 
-  <label class="form-field">
-    <span>Server URL</span>
+  <label class="flex flex-col gap-1.5">
+    <span class="text-sm text-surface-500">Server URL</span>
     <input
       type="url"
+      class="input"
       bind:value={serverUrl}
       placeholder="https://caldav.example.com"
       disabled={saving}
     />
   </label>
 
-  <label class="form-field">
-    <span>Username</span>
+  <label class="flex flex-col gap-1.5">
+    <span class="text-sm text-surface-500">Username</span>
     <input
       type="text"
+      class="input"
       bind:value={username}
       placeholder="Username"
       disabled={saving}
     />
   </label>
 
-  <label class="form-field">
-    <span>Password</span>
+  <label class="flex flex-col gap-1.5">
+    <span class="text-sm text-surface-500">Password</span>
     <input
       type="password"
+      class="input"
       bind:value={password}
       placeholder="Password"
       disabled={saving}
     />
   </label>
 
-  <div class="test-section">
+  <div class="flex flex-col gap-3 pt-2">
     <button
       type="button"
-      class="test-btn"
+      class="btn preset-outlined self-start"
       onclick={handleTestConnection}
       disabled={!serverUrl.trim() || !username.trim() || !password.trim() || accountStore.testing || saving}
     >
@@ -181,33 +185,33 @@
 
     {#if accountStore.testResult}
       {#if accountStore.testResult.success}
-        <div class="test-result success">
-          <svg class="icon" viewBox="0 0 24 24" fill="currentColor">
+        <div class="flex items-center gap-2 p-3 bg-success-500/20 rounded-md text-sm text-success-700 dark:text-success-300">
+          <svg class="w-[18px] h-[18px] shrink-0" viewBox="0 0 24 24" fill="currentColor">
             <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
           </svg>
           <span>Connection successful!</span>
         </div>
         {#if discoveredCalendars.length > 0}
-          <div class="calendars">
-            <span class="calendars-label">Discovered calendars with tasks:</span>
-            <ul>
+          <div class="p-3 bg-surface-50-950 rounded-md text-sm">
+            <span class="block mb-2 text-surface-500">Discovered calendars with tasks:</span>
+            <ul class="m-0 p-0 list-none flex flex-col gap-1.5">
               {#each discoveredCalendars.filter(c => c.supports_vtodo) as cal}
-                <li>
+                <li class="flex items-center gap-2">
                   {#if cal.color}
-                    <span class="cal-color" style:background-color={cal.color}></span>
+                    <span class="w-3 h-3 rounded shrink-0" style:background-color={cal.color}></span>
                   {/if}
                   {cal.display_name || cal.href}
                 </li>
               {/each}
               {#if discoveredCalendars.filter(c => c.supports_vtodo).length === 0}
-                <li class="no-calendars">No calendars with task support found</li>
+                <li class="text-surface-500 italic">No calendars with task support found</li>
               {/if}
             </ul>
           </div>
         {/if}
       {:else}
-        <div class="test-result error">
-          <svg class="icon" viewBox="0 0 24 24" fill="currentColor">
+        <div class="flex items-center gap-2 p-3 bg-error-500/20 rounded-md text-sm text-error-500">
+          <svg class="w-[18px] h-[18px] shrink-0" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
           </svg>
           <span>{accountStore.testResult.error || 'Connection failed'}</span>
@@ -217,14 +221,14 @@
   </div>
 
   {#if accountStore.error && !accountStore.testResult}
-    <p class="error">{accountStore.error}</p>
+    <p class="m-0 text-sm text-error-500">{accountStore.error}</p>
   {/if}
 
-  <div class="form-actions">
-    <button type="button" onclick={onClose} disabled={saving}>Cancel</button>
+  <div class="flex justify-end gap-3 pt-2">
+    <button type="button" class="btn preset-outlined" onclick={onClose} disabled={saving}>Cancel</button>
     <button
       type="submit"
-      class="primary"
+      class="btn preset-filled-primary-500"
       disabled={!name.trim() || !serverUrl.trim() || !username.trim() || !password.trim() || saving || (!isEditing && !connectionValid)}
       title={!isEditing && !connectionValid ? 'Test connection first' : ''}
     >
@@ -240,186 +244,6 @@
     </button>
   </div>
   {#if !isEditing && !connectionValid && name.trim() && serverUrl.trim() && username.trim() && password.trim()}
-    <p class="hint">Please test the connection before adding the account.</p>
+    <p class="m-0 text-[0.8125rem] text-surface-500 text-right">Please test the connection before adding the account.</p>
   {/if}
 </form>
-
-<style>
-  .account-form {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding: 1.5rem;
-    background: var(--bg-secondary);
-    border-radius: 8px;
-  }
-
-  h3 {
-    margin: 0 0 0.5rem;
-    font-size: 1.125rem;
-    font-weight: 600;
-  }
-
-  .form-field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-  }
-
-  .form-field span {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-  }
-
-  .form-field input {
-    padding: 0.625rem;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    font-size: 0.9375rem;
-    background: var(--bg-primary);
-  }
-
-  .form-field input:focus {
-    outline: none;
-    border-color: var(--accent-color);
-  }
-
-  .test-section {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    padding-top: 0.5rem;
-  }
-
-  .test-btn {
-    align-self: flex-start;
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    background: var(--bg-primary);
-    cursor: pointer;
-    font-size: 0.875rem;
-  }
-
-  .test-btn:hover:not(:disabled) {
-    background: var(--bg-hover);
-  }
-
-  .test-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .test-result {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem;
-    border-radius: 6px;
-    font-size: 0.875rem;
-  }
-
-  .test-result.success {
-    background: var(--priority-low-bg);
-    color: var(--priority-low-text);
-  }
-
-  .test-result.error {
-    background: var(--priority-high-bg);
-    color: var(--priority-high-text);
-  }
-
-  .test-result .icon {
-    width: 18px;
-    height: 18px;
-    flex-shrink: 0;
-  }
-
-  .calendars {
-    padding: 0.75rem;
-    background: var(--bg-primary);
-    border-radius: 6px;
-    font-size: 0.875rem;
-  }
-
-  .calendars-label {
-    display: block;
-    margin-bottom: 0.5rem;
-    color: var(--text-secondary);
-  }
-
-  .calendars ul {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-  }
-
-  .calendars li {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .cal-color {
-    width: 12px;
-    height: 12px;
-    border-radius: 3px;
-    flex-shrink: 0;
-  }
-
-  .no-calendars {
-    color: var(--text-secondary);
-    font-style: italic;
-  }
-
-  .error {
-    color: var(--error-color);
-    font-size: 0.875rem;
-    margin: 0;
-  }
-
-  .form-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.75rem;
-    padding-top: 0.5rem;
-  }
-
-  .form-actions button {
-    padding: 0.625rem 1.25rem;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 500;
-  }
-
-  .form-actions button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .form-actions button.primary {
-    background: var(--accent-color);
-    color: white;
-  }
-
-  .form-actions button:not(.primary) {
-    background: transparent;
-    border: 1px solid var(--border-color);
-  }
-
-  .form-actions button:not(.primary):hover:not(:disabled) {
-    background: var(--bg-hover);
-  }
-
-  .hint {
-    margin: 0;
-    font-size: 0.8125rem;
-    color: var(--text-secondary);
-    text-align: right;
-  }
-</style>

--- a/src/lib/components/AccountList.svelte
+++ b/src/lib/components/AccountList.svelte
@@ -85,11 +85,11 @@
   }
 </script>
 
-<div class="account-list">
-  <div class="header">
-    <h2>CalDAV Accounts</h2>
-    <button class="add-btn" onclick={handleAddClick}>
-      <svg viewBox="0 0 24 24" fill="currentColor">
+<div class="flex flex-col gap-4">
+  <div class="flex justify-between items-center">
+    <h2 class="m-0 text-xl font-semibold">CalDAV Accounts</h2>
+    <button class="btn preset-filled-primary-500" onclick={handleAddClick}>
+      <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="currentColor">
         <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
       </svg>
       Add Account
@@ -97,56 +97,56 @@
   </div>
 
   {#if accountStore.loading}
-    <p class="loading">Loading accounts...</p>
+    <p class="text-surface-500 text-center py-8">Loading accounts...</p>
   {:else if accountStore.accounts.length === 0 && !showAddForm}
-    <div class="empty-state">
-      <svg viewBox="0 0 24 24" fill="currentColor" class="empty-icon">
+    <div class="text-center py-12 text-surface-500">
+      <svg class="w-12 h-12 opacity-50 mx-auto mb-4" viewBox="0 0 24 24" fill="currentColor">
         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
       </svg>
-      <p>No CalDAV accounts configured</p>
-      <p class="hint">Add an account to sync tasks with your CalDAV server</p>
+      <p class="my-1">No CalDAV accounts configured</p>
+      <p class="my-1 text-sm opacity-80">Add an account to sync tasks with your CalDAV server</p>
     </div>
   {:else}
-    <ul class="accounts">
+    <ul class="list-none m-0 p-0 flex flex-col gap-2">
       {#each accountStore.accounts as account (account.id)}
-        <li class="account-item">
-          <div class="account-info">
-            <span class="account-name">{account.name}</span>
-            <span class="account-server">{account.server_url}</span>
-            <span class="account-user">{account.username}</span>
+        <li class="card flex justify-between items-center p-4 bg-surface-100-900 rounded-lg border border-surface-300-700">
+          <div class="flex flex-col gap-1 min-w-0">
+            <span class="font-medium">{account.name}</span>
+            <span class="text-sm text-surface-500 overflow-hidden text-ellipsis whitespace-nowrap">{account.server_url}</span>
+            <span class="text-[0.8125rem] text-surface-500 opacity-80">{account.username}</span>
           </div>
-          <div class="account-actions">
+          <div class="flex gap-2 shrink-0">
             <button
-              class="icon-btn sync-btn"
+              class="btn-icon preset-tonal text-primary-500"
               onclick={() => handleSyncClick(account)}
               disabled={syncStore.syncing}
               title="Sync account"
             >
               {#if syncStore.syncing && syncStore.syncingAccountId === account.id}
-                <svg class="spinning" viewBox="0 0 24 24" fill="currentColor">
+                <svg class="w-[18px] h-[18px] animate-spin" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"/>
                 </svg>
               {:else}
-                <svg viewBox="0 0 24 24" fill="currentColor">
+                <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"/>
                 </svg>
               {/if}
             </button>
             <button
-              class="icon-btn"
+              class="btn-icon preset-tonal"
               onclick={() => handleEditClick(account)}
               title="Edit account"
             >
-              <svg viewBox="0 0 24 24" fill="currentColor">
+              <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
               </svg>
             </button>
             <button
-              class="icon-btn danger"
+              class="btn-icon preset-tonal hover:preset-filled-error-500"
               onclick={() => handleDeleteClick(account)}
               title="Delete account"
             >
-              <svg viewBox="0 0 24 24" fill="currentColor">
+              <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
               </svg>
             </button>
@@ -156,18 +156,19 @@
     </ul>
 
     {#if syncStore.lastResult}
-      <div class="sync-result" class:success={syncStore.lastResult.success} class:error={!syncStore.lastResult.success}>
+      <div class="flex items-center gap-2 p-3 rounded-md text-sm mt-2
+                  {syncStore.lastResult.success ? 'bg-success-500/20 text-success-700 dark:text-success-300' : 'bg-error-500/20 text-error-500'}">
         {#if syncStore.lastResult.success}
-          <span class="sync-result-icon">✓</span>
+          <span class="font-bold">&#10003;</span>
           <span>{formatSyncResult()}</span>
         {:else}
-          <span class="sync-result-icon">✗</span>
+          <span class="font-bold">&#10007;</span>
           <span>{syncStore.lastResult.error || 'Sync failed'}</span>
         {/if}
       </div>
     {/if}
 
-    <button class="view-log-btn" onclick={() => showSyncLog = true}>
+    <button class="btn preset-outlined w-full mt-3 text-[0.8125rem]" onclick={() => showSyncLog = true}>
       View Sync Log
     </button>
   {/if}
@@ -181,229 +182,10 @@
   {/if}
 
   {#if accountStore.error && !showAddForm && !editingAccount}
-    <p class="error">{accountStore.error}</p>
+    <p class="m-0 p-3 bg-error-500/20 rounded-md text-sm text-error-500">{accountStore.error}</p>
   {/if}
 
   {#if showSyncLog}
     <SyncLogModal onClose={() => showSyncLog = false} />
   {/if}
 </div>
-
-<style>
-  .account-list {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .header h2 {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
-  }
-
-  .add-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: var(--accent-color);
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 500;
-  }
-
-  .add-btn svg {
-    width: 18px;
-    height: 18px;
-  }
-
-  .add-btn:hover {
-    opacity: 0.9;
-  }
-
-  .loading {
-    color: var(--text-secondary);
-    text-align: center;
-    padding: 2rem;
-  }
-
-  .empty-state {
-    text-align: center;
-    padding: 3rem 2rem;
-    color: var(--text-secondary);
-  }
-
-  .empty-icon {
-    width: 48px;
-    height: 48px;
-    opacity: 0.5;
-    margin-bottom: 1rem;
-  }
-
-  .empty-state p {
-    margin: 0.25rem 0;
-  }
-
-  .empty-state .hint {
-    font-size: 0.875rem;
-    opacity: 0.8;
-  }
-
-  .accounts {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .account-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem;
-    background: var(--bg-secondary);
-    border-radius: 8px;
-    border: 1px solid var(--border-color);
-  }
-
-  .account-info {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    min-width: 0;
-  }
-
-  .account-name {
-    font-weight: 500;
-    font-size: 1rem;
-  }
-
-  .account-server {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .account-user {
-    font-size: 0.8125rem;
-    color: var(--text-secondary);
-    opacity: 0.8;
-  }
-
-  .account-actions {
-    display: flex;
-    gap: 0.5rem;
-    flex-shrink: 0;
-  }
-
-  .icon-btn {
-    width: 32px;
-    height: 32px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-secondary);
-  }
-
-  .icon-btn svg {
-    width: 18px;
-    height: 18px;
-  }
-
-  .icon-btn:hover {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-
-  .icon-btn.danger:hover {
-    background: var(--priority-high-bg);
-    color: var(--priority-high-text);
-  }
-
-  .icon-btn.sync-btn {
-    color: var(--accent-color);
-  }
-
-  .icon-btn.sync-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .spinning {
-    animation: spin 1s linear infinite;
-  }
-
-  @keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
-  }
-
-  .sync-result {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
-    border-radius: 6px;
-    font-size: 0.875rem;
-    margin-top: 0.5rem;
-  }
-
-  .sync-result.success {
-    background: var(--priority-low-bg);
-    color: var(--priority-low-text);
-  }
-
-  .sync-result.error {
-    background: var(--priority-high-bg);
-    color: var(--priority-high-text);
-  }
-
-  .sync-result-icon {
-    font-weight: bold;
-  }
-
-  .error {
-    color: var(--error-color);
-    font-size: 0.875rem;
-    padding: 0.75rem;
-    background: var(--priority-high-bg);
-    border-radius: 6px;
-    margin: 0;
-  }
-
-  .view-log-btn {
-    display: block;
-    width: 100%;
-    padding: 0.5rem;
-    margin-top: 0.75rem;
-    background: transparent;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    color: var(--text-secondary);
-  }
-
-  .view-log-btn:hover {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-</style>

--- a/src/lib/components/DeleteListModal.svelte
+++ b/src/lib/components/DeleteListModal.svelte
@@ -70,59 +70,68 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-<div class="modal-backdrop" onclick={handleBackdropClick}>
-  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-    <div class="modal-header">
-      <h2 id="modal-title">Delete List</h2>
-      <button class="close-btn" onclick={onClose} aria-label="Close">
-        <svg viewBox="0 0 24 24" fill="currentColor">
+<div
+  class="fixed inset-0 bg-black/50 flex items-center justify-center z-[1000] p-[env(safe-area-inset-top,0)] p-[env(safe-area-inset-right,0)] p-[env(safe-area-inset-bottom,0)] p-[env(safe-area-inset-left,0)]"
+  onclick={handleBackdropClick}
+>
+  <div class="card bg-surface-50-950 rounded-xl shadow-xl w-[90%] max-w-md flex flex-col" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <header class="flex justify-between items-center p-4 px-6 border-b border-surface-300-700">
+      <h2 id="modal-title" class="m-0 text-xl font-semibold">Delete List</h2>
+      <button
+        class="btn-icon preset-tonal"
+        onclick={onClose}
+        aria-label="Close"
+      >
+        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
         </svg>
       </button>
-    </div>
+    </header>
 
-    <div class="modal-body">
+    <div class="p-6">
       {#if loading}
-        <p class="loading">Loading...</p>
+        <p class="text-center text-surface-500 py-4">Loading...</p>
       {:else if step === 'confirm'}
-        <p class="message">
+        <p class="m-0 mb-4 text-base leading-relaxed">
           Are you sure you want to delete <strong>{list.name}</strong>?
         </p>
         {#if isSynced}
-          <p class="sync-warning">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="warning-icon">
+          <div class="flex items-start gap-2 mb-4 p-3 bg-warning-500/20 rounded-lg text-sm text-warning-700 dark:text-warning-300">
+            <svg class="w-5 h-5 shrink-0 text-warning-500" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
             </svg>
-            This list is synced to a CalDAV server and will also be deleted from the server.
-          </p>
+            <span>This list is synced to a CalDAV server and will also be deleted from the server.</span>
+          </div>
         {/if}
         {#if error}
-          <p class="error">{error}</p>
+          <p class="m-0 mb-4 p-3 bg-error-500/20 rounded-lg text-sm text-error-500">{error}</p>
         {/if}
-        <div class="button-group">
-          <button class="btn-secondary" onclick={onClose} disabled={deleting}>
+        <div class="flex gap-3 justify-end flex-col-reverse md:flex-row">
+          <button class="btn preset-outlined min-h-11" onclick={onClose} disabled={deleting}>
             Cancel
           </button>
-          <button class="btn-danger" onclick={handleFirstConfirm} disabled={deleting}>
+          <button class="btn preset-filled-error-500 min-h-11" onclick={handleFirstConfirm} disabled={deleting}>
             {deleting ? 'Deleting...' : 'Delete'}
           </button>
         </div>
       {:else}
-        <p class="message warning-text">
-          <svg viewBox="0 0 24 24" fill="currentColor" class="warning-icon large">
+        <div class="flex items-start gap-3 mb-4 text-error-500">
+          <svg class="w-6 h-6 shrink-0" viewBox="0 0 24 24" fill="currentColor">
             <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>
           </svg>
-          This list contains <strong>{taskCount}</strong> {taskCount === 1 ? 'task' : 'tasks'} that will also be deleted.
-        </p>
-        <p class="secondary-message">This action cannot be undone.</p>
+          <p class="m-0">
+            This list contains <strong>{taskCount}</strong> {taskCount === 1 ? 'task' : 'tasks'} that will also be deleted.
+          </p>
+        </div>
+        <p class="m-0 mb-4 text-sm text-surface-500">This action cannot be undone.</p>
         {#if error}
-          <p class="error">{error}</p>
+          <p class="m-0 mb-4 p-3 bg-error-500/20 rounded-lg text-sm text-error-500">{error}</p>
         {/if}
-        <div class="button-group">
-          <button class="btn-secondary" onclick={() => step = 'confirm'} disabled={deleting}>
+        <div class="flex gap-3 justify-end flex-col-reverse md:flex-row">
+          <button class="btn preset-outlined min-h-11" onclick={() => step = 'confirm'} disabled={deleting}>
             Back
           </button>
-          <button class="btn-danger" onclick={handleDelete} disabled={deleting}>
+          <button class="btn preset-filled-error-500 min-h-11" onclick={handleDelete} disabled={deleting}>
             {deleting ? 'Deleting...' : 'Delete Forever'}
           </button>
         </div>
@@ -130,185 +139,3 @@
     </div>
   </div>
 </div>
-
-<style>
-  .modal-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.5);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-    padding: env(safe-area-inset-top, 0) env(safe-area-inset-right, 0) env(safe-area-inset-bottom, 0) env(safe-area-inset-left, 0);
-  }
-
-  .modal {
-    background: var(--bg-primary);
-    border-radius: 12px;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
-    width: 90%;
-    max-width: 400px;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .modal-header h2 {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
-  }
-
-  .close-btn {
-    width: 32px;
-    height: 32px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-secondary);
-  }
-
-  .close-btn svg {
-    width: 20px;
-    height: 20px;
-  }
-
-  .close-btn:hover {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-
-  .modal-body {
-    padding: 1.5rem;
-  }
-
-  .loading {
-    text-align: center;
-    color: var(--text-secondary);
-    padding: 1rem 0;
-  }
-
-  .message {
-    margin: 0 0 1rem;
-    font-size: 1rem;
-    line-height: 1.5;
-  }
-
-  .message strong {
-    color: var(--text-primary);
-  }
-
-  .warning-text {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.75rem;
-    color: var(--error-color, #ef4444);
-  }
-
-  .warning-icon {
-    width: 20px;
-    height: 20px;
-    flex-shrink: 0;
-    color: var(--warning-color, #f59e0b);
-  }
-
-  .warning-icon.large {
-    width: 24px;
-    height: 24px;
-    color: var(--error-color, #ef4444);
-  }
-
-  .sync-warning {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
-    margin: 0 0 1rem;
-    padding: 0.75rem;
-    background: var(--warning-bg, #fef3c7);
-    border-radius: 8px;
-    font-size: 0.875rem;
-    color: var(--warning-text, #92400e);
-  }
-
-  .secondary-message {
-    margin: 0 0 1rem;
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-  }
-
-  .error {
-    margin: 0 0 1rem;
-    padding: 0.75rem;
-    background: var(--error-bg, #fee2e2);
-    border-radius: 8px;
-    font-size: 0.875rem;
-    color: var(--error-color, #ef4444);
-  }
-
-  .button-group {
-    display: flex;
-    gap: 0.75rem;
-    justify-content: flex-end;
-  }
-
-  .button-group button {
-    padding: 0.75rem 1.25rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    border-radius: 8px;
-    cursor: pointer;
-    border: none;
-    min-height: 44px;
-  }
-
-  .btn-secondary {
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-    border: 1px solid var(--border-color);
-  }
-
-  .btn-secondary:hover:not(:disabled) {
-    background: var(--bg-hover);
-  }
-
-  .btn-danger {
-    background: var(--error-color, #ef4444);
-    color: white;
-  }
-
-  .btn-danger:hover:not(:disabled) {
-    background: #dc2626;
-  }
-
-  .button-group button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  /* Mobile responsive */
-  @media (max-width: 768px) {
-    .modal {
-      margin: 1rem;
-    }
-
-    .button-group {
-      flex-direction: column-reverse;
-    }
-
-    .button-group button {
-      width: 100%;
-    }
-  }
-</style>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -127,12 +127,20 @@
   }
 </script>
 
-<aside class="sidebar" class:mobile={isMobile} class:open={isOpen}>
+<aside
+  class="w-60 bg-surface-100-900 border-r border-surface-300-700 flex flex-col h-full
+         {isMobile ? 'fixed top-0 left-0 w-70 z-100 shadow-lg transition-transform duration-300' : ''}
+         {isMobile && !isOpen ? '-translate-x-full' : ''}"
+>
   {#if isMobile}
-    <div class="sidebar-header mobile-close-header">
-      <h2>Menu</h2>
-      <button class="close-btn" onclick={onClose} aria-label="Close menu">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <div class="flex justify-between items-center p-4 pt-[calc(1rem+var(--safe-area-top))] border-b border-surface-300-700">
+      <h2 class="m-0 text-base font-semibold">Menu</h2>
+      <button
+        class="btn-icon preset-tonal"
+        onclick={onClose}
+        aria-label="Close menu"
+      >
+        <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="18" y1="6" x2="6" y2="18"></line>
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
@@ -140,129 +148,139 @@
     </div>
   {/if}
 
-  <div class="sidebar-header">
-    <h2>Views</h2>
+  <div class="flex justify-between items-center p-4 border-b border-surface-300-700">
+    <h2 class="m-0 text-base font-semibold">Views</h2>
   </div>
 
-  <nav class="special-nav">
+  <nav class="p-2 border-b border-surface-300-700">
     <button
-      class="special-item"
-      class:selected={listStore.selectedSpecialView === 'today'}
+      class="w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-sm text-left transition-colors
+             {listStore.selectedSpecialView === 'today' ? 'bg-surface-200-800' : 'hover:bg-surface-200-800'}"
       onclick={() => handleNavigation(() => listStore.selectSpecial('today'))}
     >
-      <svg class="special-icon" viewBox="0 0 24 24" fill="currentColor">
+      <svg class="w-[18px] h-[18px] shrink-0 text-surface-500" viewBox="0 0 24 24" fill="currentColor">
         <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"/>
       </svg>
-      <span class="list-name">Today</span>
+      <span>Today</span>
     </button>
     <button
-      class="special-item"
-      class:selected={listStore.selectedSpecialView === 'overdue'}
+      class="w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-sm text-left transition-colors
+             {listStore.selectedSpecialView === 'overdue' ? 'bg-surface-200-800' : 'hover:bg-surface-200-800'}"
       onclick={() => handleNavigation(() => listStore.selectSpecial('overdue'))}
     >
-      <svg class="special-icon" viewBox="0 0 24 24" fill="currentColor">
+      <svg class="w-[18px] h-[18px] shrink-0 text-surface-500" viewBox="0 0 24 24" fill="currentColor">
         <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>
       </svg>
-      <span class="list-name">Overdue</span>
+      <span>Overdue</span>
     </button>
   </nav>
 
-  <div class="sidebar-header">
-    <h2>Lists</h2>
-    <button class="icon-btn" onclick={() => isAdding = true} title="Add list">+</button>
+  <div class="flex justify-between items-center p-4 border-b border-surface-300-700">
+    <h2 class="m-0 text-base font-semibold">Lists</h2>
+    <button
+      class="btn-icon preset-tonal size-7"
+      onclick={() => isAdding = true}
+      title="Add list"
+    >
+      +
+    </button>
   </div>
 
   {#if isAdding}
-    <form class="list-form" onsubmit={handleAddList} onkeydown={handleKeydown}>
+    <form class="p-2 px-4 flex flex-col gap-2 border-b border-surface-300-700" onsubmit={handleAddList} onkeydown={handleKeydown}>
       <input
         type="text"
+        class="input text-sm"
         bind:value={newListName}
         placeholder="List name..."
         autofocus
       />
       {#if accountStore.accounts.length > 0}
-        <select bind:value={newListAccountId} class="account-select">
+        <select bind:value={newListAccountId} class="input text-sm min-h-11">
           <option value={null}>Local only</option>
           {#each accountStore.accounts as account (account.id)}
             <option value={account.id}>{account.name}</option>
           {/each}
         </select>
       {/if}
-      <div class="color-picker">
+      <div class="flex gap-1.5 flex-wrap">
         {#each COLORS as color}
           <button
             type="button"
-            class="color-option"
-            class:selected={newListColor === color}
+            class="w-5 h-5 rounded border-2 p-0 cursor-pointer transition-transform hover:scale-110
+                   {newListColor === color ? 'border-surface-900 dark:border-surface-50' : 'border-transparent'}"
             style:background-color={color}
             onclick={() => newListColor = color}
             title={color}
           ></button>
         {/each}
       </div>
-      <div class="form-buttons">
-        <button type="submit" class="primary" disabled={!newListName.trim()}>Add</button>
-        <button type="button" onclick={() => { isAdding = false; newListName = ''; newListColor = COLORS[0]; newListAccountId = null; }}>Cancel</button>
+      <div class="flex gap-2">
+        <button type="submit" class="btn btn-sm preset-filled-primary-500" disabled={!newListName.trim()}>Add</button>
+        <button type="button" class="btn btn-sm preset-outlined" onclick={() => { isAdding = false; newListName = ''; newListColor = COLORS[0]; newListAccountId = null; }}>Cancel</button>
       </div>
     </form>
   {/if}
 
-  <nav class="list-nav">
+  <nav class="flex-1 overflow-y-auto p-2">
     <!-- Local lists section -->
     {#if groupedLists().localLists.length > 0}
-      <div class="list-section-header">Local</div>
+      <div class="text-[0.6875rem] font-semibold uppercase tracking-wide text-surface-500 px-3 py-1.5 mt-1">Local</div>
       {#each groupedLists().localLists as list (list.id)}
         {#if editingList?.id === list.id}
-          <form class="list-form inline" onsubmit={handleEditList} onkeydown={handleKeydown}>
+          <form class="p-2 bg-surface-200-800 rounded-md mb-1 flex flex-col gap-2" onsubmit={handleEditList} onkeydown={handleKeydown}>
             <input
               type="text"
+              class="input text-sm"
               bind:value={editName}
               autofocus
             />
-            <div class="color-picker">
+            <div class="flex gap-1.5 flex-wrap">
               {#each COLORS as color}
                 <button
                   type="button"
-                  class="color-option"
-                  class:selected={editColor === color}
+                  class="w-5 h-5 rounded border-2 p-0 cursor-pointer transition-transform hover:scale-110
+                         {editColor === color ? 'border-surface-900 dark:border-surface-50' : 'border-transparent'}"
                   style:background-color={color}
                   onclick={() => editColor = color}
                   title={color}
                 ></button>
               {/each}
             </div>
-            <div class="form-buttons">
-              <button type="submit" class="primary" disabled={!editName.trim()}>Save</button>
-              <button type="button" onclick={() => editingList = null}>Cancel</button>
+            <div class="flex gap-2">
+              <button type="submit" class="btn btn-sm preset-filled-primary-500" disabled={!editName.trim()}>Save</button>
+              <button type="button" class="btn btn-sm preset-outlined" onclick={() => editingList = null}>Cancel</button>
             </div>
           </form>
         {:else}
           <div
-            class="list-item"
-            class:selected={list.id === listStore.selectedListId}
+            class="flex items-center gap-2 p-1.5 rounded-md text-sm group
+                   {list.id === listStore.selectedListId ? 'bg-surface-200-800' : 'hover:bg-surface-200-800'}"
           >
             <button
               type="button"
-              class="list-color-btn"
+              class="w-3.5 h-3.5 rounded shrink-0 border-none cursor-pointer p-0 hover:scale-115 transition-transform"
               style:background-color={list.color ?? '#6b7280'}
               onclick={() => startEdit(list)}
               title="Edit list"
             ></button>
             <button
               type="button"
-              class="list-name-btn"
+              class="flex-1 text-left bg-transparent border-none cursor-pointer text-sm px-1.5 py-1 rounded overflow-hidden text-ellipsis whitespace-nowrap hover:bg-surface-200-800"
               onclick={() => handleNavigation(() => listStore.select(list.id))}
             >
               {list.name}
             </button>
             <button
               type="button"
-              class="delete-btn"
-              class:mobile={isMobile}
+              class="shrink-0 w-7 h-7 p-0 border-none bg-transparent cursor-pointer rounded flex items-center justify-center
+                     text-surface-500 transition-opacity
+                     {isMobile ? 'opacity-100 w-11 h-11' : 'opacity-0 group-hover:opacity-100'}
+                     hover:bg-error-500 hover:text-white"
               onclick={(e) => handleDeleteClick(list, e)}
               title="Delete list"
             >
-              <svg viewBox="0 0 24 24" fill="currentColor">
+              <svg class="w-3.5 h-3.5 {isMobile ? 'w-[18px] h-[18px]' : ''}" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
               </svg>
             </button>
@@ -273,59 +291,62 @@
 
     <!-- Account lists sections -->
     {#each [...groupedLists().accountLists.entries()] as [accountId, lists] (accountId)}
-      <div class="list-section-header">{getAccountName(accountId)}</div>
+      <div class="text-[0.6875rem] font-semibold uppercase tracking-wide text-surface-500 px-3 py-1.5 mt-3">{getAccountName(accountId)}</div>
       {#each lists as list (list.id)}
         {#if editingList?.id === list.id}
-          <form class="list-form inline" onsubmit={handleEditList} onkeydown={handleKeydown}>
+          <form class="p-2 bg-surface-200-800 rounded-md mb-1 flex flex-col gap-2" onsubmit={handleEditList} onkeydown={handleKeydown}>
             <input
               type="text"
+              class="input text-sm"
               bind:value={editName}
               autofocus
             />
-            <div class="color-picker">
+            <div class="flex gap-1.5 flex-wrap">
               {#each COLORS as color}
                 <button
                   type="button"
-                  class="color-option"
-                  class:selected={editColor === color}
+                  class="w-5 h-5 rounded border-2 p-0 cursor-pointer transition-transform hover:scale-110
+                         {editColor === color ? 'border-surface-900 dark:border-surface-50' : 'border-transparent'}"
                   style:background-color={color}
                   onclick={() => editColor = color}
                   title={color}
                 ></button>
               {/each}
             </div>
-            <div class="form-buttons">
-              <button type="submit" class="primary" disabled={!editName.trim()}>Save</button>
-              <button type="button" onclick={() => editingList = null}>Cancel</button>
+            <div class="flex gap-2">
+              <button type="submit" class="btn btn-sm preset-filled-primary-500" disabled={!editName.trim()}>Save</button>
+              <button type="button" class="btn btn-sm preset-outlined" onclick={() => editingList = null}>Cancel</button>
             </div>
           </form>
         {:else}
           <div
-            class="list-item"
-            class:selected={list.id === listStore.selectedListId}
+            class="flex items-center gap-2 p-1.5 rounded-md text-sm group
+                   {list.id === listStore.selectedListId ? 'bg-surface-200-800' : 'hover:bg-surface-200-800'}"
           >
             <button
               type="button"
-              class="list-color-btn"
+              class="w-3.5 h-3.5 rounded shrink-0 border-none cursor-pointer p-0 hover:scale-115 transition-transform"
               style:background-color={list.color ?? '#6b7280'}
               onclick={() => startEdit(list)}
               title="Edit list"
             ></button>
             <button
               type="button"
-              class="list-name-btn"
+              class="flex-1 text-left bg-transparent border-none cursor-pointer text-sm px-1.5 py-1 rounded overflow-hidden text-ellipsis whitespace-nowrap hover:bg-surface-200-800"
               onclick={() => handleNavigation(() => listStore.select(list.id))}
             >
               {list.name}
             </button>
             <button
               type="button"
-              class="delete-btn"
-              class:mobile={isMobile}
+              class="shrink-0 w-7 h-7 p-0 border-none bg-transparent cursor-pointer rounded flex items-center justify-center
+                     text-surface-500 transition-opacity
+                     {isMobile ? 'opacity-100 w-11 h-11' : 'opacity-0 group-hover:opacity-100'}
+                     hover:bg-error-500 hover:text-white"
               onclick={(e) => handleDeleteClick(list, e)}
               title="Delete list"
             >
-              <svg viewBox="0 0 24 24" fill="currentColor">
+              <svg class="w-3.5 h-3.5 {isMobile ? 'w-[18px] h-[18px]' : ''}" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
               </svg>
             </button>
@@ -336,24 +357,24 @@
   </nav>
 
   {#if listStore.error}
-    <p class="error">{listStore.error}</p>
+    <p class="px-4 py-2 text-xs text-error-500">{listStore.error}</p>
   {/if}
 
-  <div class="sidebar-footer">
+  <div class="mt-auto p-2 border-t border-surface-300-700">
     {#if syncStore.syncing}
-      <div class="sync-indicator">
-        <svg class="spinning" viewBox="0 0 24 24" fill="currentColor">
+      <div class="flex items-center gap-2 px-3 py-2 text-[0.8125rem] text-primary-500">
+        <svg class="w-4 h-4 shrink-0 animate-spin" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"/>
         </svg>
         <span>Syncing...</span>
       </div>
     {/if}
     <button
-      class="settings-btn"
-      class:active={showSettings}
+      class="w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-sm text-left text-surface-500 transition-colors
+             {showSettings ? 'bg-surface-200-800 text-surface-900 dark:text-surface-50' : 'hover:bg-surface-200-800 hover:text-surface-900 dark:hover:text-surface-50'}"
       onclick={() => handleNavigation(() => onToggleSettings?.())}
     >
-      <svg viewBox="0 0 24 24" fill="currentColor">
+      <svg class="w-[18px] h-[18px] shrink-0" viewBox="0 0 24 24" fill="currentColor">
         <path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/>
       </svg>
       <span>Settings</span>
@@ -364,398 +385,3 @@
 {#if listToDelete}
   <DeleteListModal list={listToDelete} onClose={() => listToDelete = null} />
 {/if}
-
-<style>
-  .sidebar {
-    width: 240px;
-    background: var(--bg-secondary);
-    border-right: 1px solid var(--border-color);
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-  }
-
-  /* Mobile drawer styles */
-  .sidebar.mobile {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 280px;
-    height: 100%;
-    z-index: 100;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
-    border-right: none;
-    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-  }
-
-  .sidebar.mobile.open {
-    transform: translateX(0);
-  }
-
-  .sidebar.mobile .sidebar-header {
-    padding-top: calc(1rem + env(safe-area-inset-top, 0));
-  }
-
-  .mobile-close-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .close-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 44px;
-    height: 44px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-primary);
-    border-radius: 8px;
-  }
-
-  .close-btn:hover {
-    background: var(--bg-hover);
-  }
-
-  .close-btn svg {
-    width: 24px;
-    height: 24px;
-  }
-
-  .sidebar-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .sidebar-header h2 {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-  }
-
-  .icon-btn {
-    width: 28px;
-    height: 28px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    font-size: 1.25rem;
-    border-radius: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .icon-btn:hover {
-    background: var(--bg-hover);
-  }
-
-  .list-form {
-    padding: 0.5rem 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .list-form.inline {
-    padding: 0.5rem;
-    border-bottom: none;
-    background: var(--bg-hover);
-    border-radius: 6px;
-    margin-bottom: 0.25rem;
-  }
-
-  .list-form input {
-    padding: 0.5rem;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    font-size: 0.875rem;
-    background: var(--bg-primary);
-  }
-
-  .account-select {
-    width: 100%;
-    padding: 0.5rem;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    font-size: 0.875rem;
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    min-height: 44px;
-  }
-
-  .color-picker {
-    display: flex;
-    gap: 0.375rem;
-    flex-wrap: wrap;
-  }
-
-  .color-option {
-    width: 20px;
-    height: 20px;
-    border: 2px solid transparent;
-    border-radius: 4px;
-    cursor: pointer;
-    padding: 0;
-  }
-
-  .color-option:hover {
-    transform: scale(1.1);
-  }
-
-  .color-option.selected {
-    border-color: var(--text-primary);
-  }
-
-  .form-buttons {
-    display: flex;
-    gap: 0.5rem;
-  }
-
-  .form-buttons button {
-    padding: 0.375rem 0.75rem;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.875rem;
-  }
-
-  .form-buttons button.primary {
-    background: var(--accent-color);
-    color: white;
-  }
-
-  .form-buttons button.primary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .form-buttons button:not(.primary) {
-    background: transparent;
-  }
-
-  .special-nav {
-    padding: 0.5rem;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .special-item {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.625rem 0.75rem;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 6px;
-    text-align: left;
-    font-size: 0.875rem;
-  }
-
-  .special-item:hover {
-    background: var(--bg-hover);
-  }
-
-  .special-item.selected {
-    background: var(--bg-selected);
-  }
-
-  .special-icon {
-    width: 18px;
-    height: 18px;
-    flex-shrink: 0;
-    color: var(--text-secondary);
-  }
-
-  .special-item.selected .special-icon {
-    color: var(--text-primary);
-  }
-
-  .list-nav {
-    flex: 1;
-    overflow-y: auto;
-    padding: 0.5rem;
-  }
-
-  .list-section-header {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-secondary);
-    padding: 0.75rem 0.75rem 0.375rem;
-    margin-top: 0.25rem;
-  }
-
-  .list-section-header:first-child {
-    margin-top: 0;
-  }
-
-  .list-item {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.375rem;
-    border-radius: 6px;
-    font-size: 0.875rem;
-  }
-
-  .list-item:hover {
-    background: var(--bg-hover);
-  }
-
-  .list-item.selected {
-    background: var(--bg-selected);
-  }
-
-  .list-color-btn {
-    width: 14px;
-    height: 14px;
-    border-radius: 3px;
-    flex-shrink: 0;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-  }
-
-  .list-color-btn:hover {
-    transform: scale(1.15);
-  }
-
-  .list-name-btn {
-    flex: 1;
-    text-align: left;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    font-size: 0.875rem;
-    padding: 0.25rem 0.375rem;
-    border-radius: 4px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .list-name-btn:hover {
-    background: var(--bg-hover);
-  }
-
-  .delete-btn {
-    width: 28px;
-    height: 28px;
-    padding: 0;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-secondary);
-    opacity: 0;
-    flex-shrink: 0;
-    transition: opacity 0.15s ease;
-  }
-
-  .delete-btn svg {
-    width: 14px;
-    height: 14px;
-  }
-
-  .list-item:hover .delete-btn {
-    opacity: 1;
-  }
-
-  .delete-btn:hover {
-    background: var(--error-color, #ef4444);
-    color: white;
-  }
-
-  /* Mobile: always show delete button */
-  .delete-btn.mobile {
-    opacity: 1;
-    width: 44px;
-    height: 44px;
-  }
-
-  .delete-btn.mobile svg {
-    width: 18px;
-    height: 18px;
-  }
-
-  .error {
-    padding: 0.5rem 1rem;
-    color: var(--error-color);
-    font-size: 0.75rem;
-  }
-
-  .sidebar-footer {
-    margin-top: auto;
-    padding: 0.5rem;
-    border-top: 1px solid var(--border-color);
-  }
-
-  .settings-btn {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.625rem 0.75rem;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 6px;
-    text-align: left;
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-  }
-
-  .settings-btn svg {
-    width: 18px;
-    height: 18px;
-    flex-shrink: 0;
-  }
-
-  .settings-btn:hover {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-
-  .settings-btn.active {
-    background: var(--bg-selected);
-    color: var(--text-primary);
-  }
-
-  .sync-indicator {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    font-size: 0.8125rem;
-    color: var(--accent-color);
-  }
-
-  .sync-indicator svg {
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-  }
-
-  .spinning {
-    animation: spin 1s linear infinite;
-  }
-
-  @keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
-  }
-</style>

--- a/src/lib/components/SyncLogModal.svelte
+++ b/src/lib/components/SyncLogModal.svelte
@@ -65,10 +65,10 @@
 
   function getStatusClass(status: string): string {
     switch (status) {
-      case 'success': return 'status-success';
-      case 'error': return 'status-error';
-      case 'conflict': return 'status-conflict';
-      default: return '';
+      case 'success': return 'preset-filled-success-500';
+      case 'error': return 'preset-filled-error-500';
+      case 'conflict': return 'preset-filled-warning-500';
+      default: return 'preset-filled-surface-500';
     }
   }
 
@@ -91,52 +91,65 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-<div class="modal-backdrop" onclick={handleBackdropClick}>
-  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-    <div class="modal-header">
-      <h2 id="modal-title">Sync Log</h2>
-      <button class="close-btn" onclick={onClose} aria-label="Close">
-        <svg viewBox="0 0 24 24" fill="currentColor">
+<div
+  class="fixed inset-0 bg-black/50 flex items-center justify-center z-[1000]"
+  onclick={handleBackdropClick}
+>
+  <div class="card bg-surface-50-950 rounded-xl shadow-xl w-[90%] max-w-[600px] max-h-[80vh] flex flex-col" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <header class="flex justify-between items-center p-4 px-6 border-b border-surface-300-700">
+      <h2 id="modal-title" class="m-0 text-xl font-semibold">Sync Log</h2>
+      <button
+        class="btn-icon preset-tonal"
+        onclick={onClose}
+        aria-label="Close"
+      >
+        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
         </svg>
       </button>
-    </div>
+    </header>
 
-    <div class="modal-body">
+    <div class="p-4 px-6 overflow-y-auto flex-1">
       {#if loading && entries.length === 0}
-        <p class="loading">Loading sync log...</p>
+        <p class="text-center text-surface-500 py-8">Loading sync log...</p>
       {:else if error}
-        <p class="error">{error}</p>
+        <p class="text-center text-error-500 py-8">{error}</p>
       {:else if entries.length === 0}
-        <p class="empty">No sync operations logged yet.</p>
+        <p class="text-center text-surface-500 py-8">No sync operations logged yet.</p>
       {:else}
-        <div class="table-wrapper">
-          <table class="log-table">
+        <div class="overflow-x-auto">
+          <table class="w-full border-collapse text-[0.8125rem]">
             <thead>
               <tr>
-                <th>Time</th>
-                <th>Operation</th>
-                <th>Status</th>
-                <th>Details</th>
+                <th class="p-2 px-3 text-left border-b border-surface-300-700 font-semibold text-xs uppercase text-surface-500 bg-surface-100-900 sticky top-0">Time</th>
+                <th class="p-2 px-3 text-left border-b border-surface-300-700 font-semibold text-xs uppercase text-surface-500 bg-surface-100-900 sticky top-0">Operation</th>
+                <th class="p-2 px-3 text-left border-b border-surface-300-700 font-semibold text-xs uppercase text-surface-500 bg-surface-100-900 sticky top-0">Status</th>
+                <th class="p-2 px-3 text-left border-b border-surface-300-700 font-semibold text-xs uppercase text-surface-500 bg-surface-100-900 sticky top-0">Details</th>
               </tr>
             </thead>
             <tbody>
               {#each entries as entry (entry.id)}
-                <tr>
-                  <td class="timestamp">{formatTimestamp(entry.timestamp)}</td>
-                  <td>{getOperationLabel(entry.operation)}</td>
-                  <td><span class="status {getStatusClass(entry.status)}">{entry.status}</span></td>
-                  <td class="details">
-                    {#if entry.message}
-                      <span class="message">{entry.message}</span>
-                    {/if}
-                    {#if entry.list_id || entry.task_id || entry.http_status}
-                      <span class="meta">
-                        {#if entry.list_id}List: {entry.list_id}{/if}
-                        {#if entry.task_id}{entry.list_id ? ' · ' : ''}Task: {entry.task_id}{/if}
-                        {#if entry.http_status}{(entry.list_id || entry.task_id) ? ' · ' : ''}HTTP: {entry.http_status}{/if}
-                      </span>
-                    {/if}
+                <tr class="hover:bg-surface-100-900">
+                  <td class="p-2 px-3 border-b border-surface-300-700 whitespace-nowrap text-surface-500 text-xs">{formatTimestamp(entry.timestamp)}</td>
+                  <td class="p-2 px-3 border-b border-surface-300-700">{getOperationLabel(entry.operation)}</td>
+                  <td class="p-2 px-3 border-b border-surface-300-700">
+                    <span class="badge text-[0.6875rem] px-2 py-0.5 uppercase font-medium whitespace-nowrap {getStatusClass(entry.status)}">
+                      {entry.status}
+                    </span>
+                  </td>
+                  <td class="p-2 px-3 border-b border-surface-300-700">
+                    <div class="flex flex-col gap-1">
+                      {#if entry.message}
+                        <span class="text-surface-500 break-words">{entry.message}</span>
+                      {/if}
+                      {#if entry.list_id || entry.task_id || entry.http_status}
+                        <span class="text-[0.6875rem] text-surface-500 opacity-80">
+                          {#if entry.list_id}List: {entry.list_id}{/if}
+                          {#if entry.task_id}{entry.list_id ? ' · ' : ''}Task: {entry.task_id}{/if}
+                          {#if entry.http_status}{(entry.list_id || entry.task_id) ? ' · ' : ''}HTTP: {entry.http_status}{/if}
+                        </span>
+                      {/if}
+                    </div>
                   </td>
                 </tr>
               {/each}
@@ -146,7 +159,7 @@
 
         {#if hasMore}
           <button
-            class="load-more-btn"
+            class="btn preset-outlined w-full mt-4"
             onclick={() => loadEntries(true)}
             disabled={loading}
           >
@@ -157,181 +170,3 @@
     </div>
   </div>
 </div>
-
-<style>
-  .modal-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.5);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-  }
-
-  .modal {
-    background: var(--bg-primary);
-    border-radius: 12px;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
-    width: 90%;
-    max-width: 600px;
-    max-height: 80vh;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .modal-header h2 {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
-  }
-
-  .close-btn {
-    width: 32px;
-    height: 32px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-secondary);
-  }
-
-  .close-btn svg {
-    width: 20px;
-    height: 20px;
-  }
-
-  .close-btn:hover {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-
-  .modal-body {
-    padding: 1rem 1.5rem;
-    overflow-y: auto;
-    flex: 1;
-  }
-
-  .loading,
-  .empty,
-  .error {
-    text-align: center;
-    padding: 2rem;
-    color: var(--text-secondary);
-  }
-
-  .error {
-    color: var(--error-color, #ef4444);
-  }
-
-  .table-wrapper {
-    overflow-x: auto;
-  }
-
-  .log-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.8125rem;
-  }
-
-  .log-table th,
-  .log-table td {
-    padding: 0.5rem 0.75rem;
-    text-align: left;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .log-table th {
-    font-weight: 600;
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    color: var(--text-secondary);
-    background: var(--bg-secondary);
-    position: sticky;
-    top: 0;
-  }
-
-  .log-table tbody tr:hover {
-    background: var(--bg-hover);
-  }
-
-  .timestamp {
-    white-space: nowrap;
-    color: var(--text-secondary);
-    font-size: 0.75rem;
-  }
-
-  .status {
-    font-size: 0.6875rem;
-    padding: 0.125rem 0.5rem;
-    border-radius: 4px;
-    text-transform: uppercase;
-    font-weight: 500;
-    white-space: nowrap;
-  }
-
-  .status-success {
-    background: var(--priority-low-bg, #dcfce7);
-    color: var(--priority-low-text, #166534);
-  }
-
-  .status-error {
-    background: var(--priority-high-bg, #fee2e2);
-    color: var(--priority-high-text, #991b1b);
-  }
-
-  .status-conflict {
-    background: var(--priority-medium-bg, #fef3c7);
-    color: var(--priority-medium-text, #92400e);
-  }
-
-  .details {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-
-  .message {
-    color: var(--text-secondary);
-    word-break: break-word;
-  }
-
-  .meta {
-    font-size: 0.6875rem;
-    color: var(--text-secondary);
-    opacity: 0.8;
-  }
-
-  .load-more-btn {
-    display: block;
-    width: 100%;
-    padding: 0.75rem;
-    margin-top: 1rem;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    color: var(--text-primary);
-  }
-
-  .load-more-btn:hover:not(:disabled) {
-    background: var(--bg-hover);
-  }
-
-  .load-more-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-</style>

--- a/src/lib/components/SyncStatus.svelte
+++ b/src/lib/components/SyncStatus.svelte
@@ -85,99 +85,32 @@
 </script>
 
 {#if status?.has_caldav}
-  <div class="sync-status">
+  <div class="flex items-center gap-2">
     <button
-      class="sync-button"
+      class="btn btn-sm preset-outlined flex items-center gap-1"
       onclick={handleSync}
       disabled={syncing}
       title={status.last_sync ? `Last sync: ${formatRelativeTime(status.last_sync)}` : 'Never synced'}
     >
       {#if syncing}
-        <span class="spinner"></span>
+        <span class="w-3.5 h-3.5 border-2 border-surface-300-700 border-t-primary-500 rounded-full animate-spin"></span>
         Syncing...
       {:else}
         Sync
         {#if status.pending_changes > 0}
-          <span class="pending-badge">{status.pending_changes}</span>
+          <span class="badge preset-filled-primary-500 text-xs min-w-5 h-5 px-1">
+            {status.pending_changes}
+          </span>
         {/if}
       {/if}
     </button>
 
     {#if error}
-      <span class="sync-error" title={error}>Sync failed</span>
+      <span class="text-xs text-error-500" title={error}>Sync failed</span>
     {:else if status.failed_changes > 0 && status.last_error}
-      <span class="sync-error" title={status.last_error}>{status.failed_changes} failed</span>
+      <span class="text-xs text-error-500" title={status.last_error}>{status.failed_changes} failed</span>
     {:else if syncSummary()}
-      <span class="sync-summary">{syncSummary()}</span>
+      <span class="text-xs text-surface-500">{syncSummary()}</span>
     {/if}
   </div>
 {/if}
-
-<style>
-  .sync-status {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .sync-button {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.375rem 0.75rem;
-    font-size: 0.8125rem;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-    cursor: pointer;
-    transition: background-color 0.15s, border-color 0.15s;
-  }
-
-  .sync-button:hover:not(:disabled) {
-    background: var(--bg-hover);
-    border-color: var(--border-hover);
-  }
-
-  .sync-button:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .pending-badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 1.25rem;
-    height: 1.25rem;
-    padding: 0 0.25rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    background: var(--accent-color, #3b82f6);
-    color: white;
-    border-radius: 10px;
-  }
-
-  .spinner {
-    width: 0.875rem;
-    height: 0.875rem;
-    border: 2px solid var(--border-color);
-    border-top-color: var(--accent-color, #3b82f6);
-    border-radius: 50%;
-    animation: spin 0.75s linear infinite;
-  }
-
-  @keyframes spin {
-    to { transform: rotate(360deg); }
-  }
-
-  .sync-error {
-    font-size: 0.75rem;
-    color: var(--error-color, #ef4444);
-  }
-
-  .sync-summary {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-  }
-</style>

--- a/src/lib/components/TaskForm.svelte
+++ b/src/lib/components/TaskForm.svelte
@@ -79,14 +79,24 @@
       onClose?.();
     }
   }
+
+  function getPriorityDotClass(p: string): string {
+    if (p === '1') return 'bg-error-500';
+    if (p === '5') return 'bg-warning-500';
+    if (p === '9') return 'bg-primary-500';
+    return '';
+  }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
 
-<form class="task-form" onsubmit={handleSubmit}>
+<form
+  class="p-4 md:px-6 flex flex-col gap-3 pb-[calc(1rem+var(--safe-area-bottom))]"
+  onsubmit={handleSubmit}
+>
   <input
     type="text"
-    class="title-input"
+    class="input"
     bind:value={title}
     placeholder="Task title..."
     disabled={saving}
@@ -94,22 +104,28 @@
   />
 
   <textarea
-    class="description-input"
+    class="input resize-y"
     bind:value={description}
     placeholder="Description (optional)"
     rows="2"
     disabled={saving}
   ></textarea>
 
-  <div class="form-row">
-    <label class="form-field">
-      <span>Due date</span>
-      <input type="date" bind:value={dueDate} disabled={saving} />
+  <div class="flex flex-col md:flex-row gap-3">
+    <label class="flex flex-col gap-1 flex-1">
+      <span class="text-xs text-surface-500">Due date</span>
+      <input
+        type="date"
+        class="input min-h-11"
+        bind:value={dueDate}
+        disabled={saving}
+      />
     </label>
 
-    <label class="form-field">
-      <span>Repeat</span>
+    <label class="flex flex-col gap-1 flex-1">
+      <span class="text-xs text-surface-500">Repeat</span>
       <select
+        class="input min-h-11"
         bind:value={rrule}
         disabled={saving || !dueDate}
         title={!dueDate ? "Set a due date first" : ""}
@@ -120,10 +136,10 @@
       </select>
     </label>
 
-    <label class="form-field">
-      <span>Priority</span>
-      <div class="priority-select-wrapper">
-        <select bind:value={priority} disabled={saving} class="priority-select">
+    <label class="flex flex-col gap-1 flex-1">
+      <span class="text-xs text-surface-500">Priority</span>
+      <div class="relative flex items-center">
+        <select class="input min-h-11 pr-8 flex-1" bind:value={priority} disabled={saving}>
           <option value="">None</option>
           <option value="1">High</option>
           <option value="5">Medium</option>
@@ -131,184 +147,28 @@
         </select>
         {#if priority}
           <span
-            class="priority-indicator priority-{priority === '1'
-              ? 'high'
-              : priority === '5'
-                ? 'medium'
-                : 'low'}"
+            class="absolute right-7 w-2 h-2 rounded-full pointer-events-none {getPriorityDotClass(priority)}"
           ></span>
         {/if}
       </div>
     </label>
   </div>
 
-  <div class="form-actions">
-    {#if isEditing}
-      <button type="button" onclick={onClose} disabled={saving}>Cancel</button>
-    {/if}
-    <button type="submit" class="primary" disabled={!title.trim() || saving}>
+  <div class="flex justify-end gap-2">
+    <button
+      type="button"
+      class="btn preset-outlined"
+      onclick={onClose}
+      disabled={saving}
+    >
+      Cancel
+    </button>
+    <button
+      type="submit"
+      class="btn preset-filled-primary-500"
+      disabled={!title.trim() || saving}
+    >
       {saving ? "Saving..." : isEditing ? "Save" : "Add Task"}
     </button>
   </div>
 </form>
-
-<style>
-  .task-form {
-    padding: 1rem 1.5rem;
-    border-top: 1px solid var(--border-color);
-    background: var(--bg-secondary);
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-
-  .title-input {
-    font-size: 1rem;
-    padding: 0.625rem;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    background: var(--bg-primary);
-  }
-
-  .title-input:focus {
-    outline: none;
-    border-color: var(--accent-color);
-  }
-
-  .description-input {
-    font-size: 0.875rem;
-    padding: 0.5rem;
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    resize: vertical;
-    font-family: inherit;
-    background: var(--bg-primary);
-  }
-
-  .description-input:focus {
-    outline: none;
-    border-color: var(--accent-color);
-  }
-
-  .form-row {
-    display: flex;
-    gap: 1rem;
-  }
-
-  .form-field {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    flex: 1;
-  }
-
-  .form-field span {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-  }
-
-  .form-field input,
-  .form-field select {
-    padding: 0.5rem;
-    border: 1px solid var(--border-color);
-    border-radius: 4px;
-    font-size: 0.875rem;
-    background: var(--bg-primary);
-  }
-
-  .priority-select-wrapper {
-    position: relative;
-    display: flex;
-    align-items: center;
-  }
-
-  .priority-select {
-    flex: 1;
-    padding-right: 2rem;
-  }
-
-  .priority-indicator {
-    position: absolute;
-    right: 1.75rem;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    pointer-events: none;
-  }
-
-  .priority-indicator.priority-high {
-    background: var(--priority-high-text);
-  }
-
-  .priority-indicator.priority-medium {
-    background: var(--priority-medium-text);
-  }
-
-  .priority-indicator.priority-low {
-    background: var(--priority-low-text);
-  }
-
-  .form-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-  }
-
-  .form-actions button {
-    padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 500;
-  }
-
-  .form-actions button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .form-actions button.primary {
-    background: var(--accent-color);
-    color: white;
-  }
-
-  .form-actions button:not(.primary) {
-    background: transparent;
-  }
-
-  .form-actions button:not(.primary):hover {
-    background: var(--bg-hover);
-  }
-
-  /* Mobile adjustments */
-  @media (max-width: 768px) {
-    .task-form {
-      padding: 1rem;
-      padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0));
-    }
-
-    .form-row {
-      flex-direction: column;
-      gap: 0.75rem;
-    }
-
-    .form-field input,
-    .form-field select {
-      padding: 0.75rem;
-      font-size: 1rem;
-      min-height: 44px;
-    }
-
-    .title-input {
-      padding: 0.75rem;
-      font-size: 1rem;
-      min-height: 44px;
-    }
-
-    .form-actions button {
-      padding: 0.75rem 1.25rem;
-      min-height: 44px;
-    }
-  }
-</style>

--- a/src/lib/components/TaskItem.svelte
+++ b/src/lib/components/TaskItem.svelte
@@ -43,6 +43,13 @@
     return 'Low';
   }
 
+  function getPriorityClass(priority: number | null): string {
+    if (priority === null) return '';
+    if (priority <= 3) return 'preset-filled-error-500';
+    if (priority <= 6) return 'preset-filled-warning-500';
+    return 'preset-filled-primary-500';
+  }
+
   function getRecurrenceLabel(rrule: string | null): string {
     if (!rrule) return '';
     if (rrule.includes('FREQ=DAILY')) return 'Daily';
@@ -57,36 +64,48 @@
   );
 </script>
 
-<div class="task-item" class:completed={task.completed}>
+<div
+  class="group flex items-start gap-3 p-3 rounded-md transition-colors hover:bg-surface-100-900"
+  class:opacity-60={task.completed}
+>
+  <!-- Checkbox -->
   <button
-    class="checkbox"
-    class:checked={task.completed}
+    class="shrink-0 mt-0.5 w-5 h-5 md:w-11 md:h-11 rounded border-2 flex items-center justify-center transition-colors
+           {task.completed
+             ? 'bg-primary-500 border-primary-500 text-white'
+             : 'border-surface-400 hover:border-primary-500'}"
     onclick={handleToggle}
     aria-label={task.completed ? 'Mark incomplete' : 'Mark complete'}
   >
     {#if task.completed}
-      <svg viewBox="0 0 24 24" fill="currentColor">
+      <svg class="w-3.5 h-3.5 md:w-6 md:h-6" viewBox="0 0 24 24" fill="currentColor">
         <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
       </svg>
     {/if}
   </button>
 
-  <button class="task-content" onclick={() => onEdit?.(task)}>
-    <span class="task-title">{task.title}</span>
-    <div class="task-meta">
+  <!-- Task Content -->
+  <button
+    class="flex-1 min-w-0 text-left bg-transparent border-none cursor-pointer p-0"
+    onclick={() => onEdit?.(task)}
+  >
+    <span class="block text-[0.9375rem]" class:line-through={task.completed}>
+      {task.title}
+    </span>
+    <div class="flex flex-wrap gap-2 mt-1 text-xs">
       {#if task.due_date}
-        <span class="due-date" class:overdue={isOverdue}>
+        <span class:text-error-500={isOverdue} class:font-medium={isOverdue} class="text-surface-500">
           {formatDueDate(task.due_date)}
         </span>
       {/if}
       {#if task.priority}
-        <span class="priority priority-{getPriorityLabel(task.priority).toLowerCase()}">
+        <span class="badge {getPriorityClass(task.priority)} text-xs px-1.5 py-0.5">
           {getPriorityLabel(task.priority)}
         </span>
       {/if}
       {#if task.rrule}
-        <span class="recurrence">
-          <svg viewBox="0 0 24 24" fill="currentColor" class="recurrence-icon">
+        <span class="flex items-center gap-1 text-surface-500">
+          <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"/>
           </svg>
           {getRecurrenceLabel(task.rrule)}
@@ -95,184 +114,16 @@
     </div>
   </button>
 
-  <button class="delete-btn" onclick={handleDelete} title="Delete task">
-    <svg viewBox="0 0 24 24" fill="currentColor">
+  <!-- Delete Button -->
+  <button
+    class="shrink-0 w-7 h-7 md:w-11 md:h-11 flex items-center justify-center rounded bg-transparent border-none cursor-pointer
+           text-surface-500 opacity-0 md:opacity-100 group-hover:opacity-100 transition-opacity
+           hover:bg-surface-200-800 hover:text-error-500"
+    onclick={handleDelete}
+    title="Delete task"
+  >
+    <svg class="w-[18px] h-[18px] md:w-6 md:h-6" viewBox="0 0 24 24" fill="currentColor">
       <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
     </svg>
   </button>
 </div>
-
-<style>
-  .task-item {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.75rem;
-    padding: 0.75rem;
-    border-radius: 6px;
-    transition: background-color 0.15s;
-  }
-
-  .task-item:hover {
-    background: var(--bg-hover);
-  }
-
-  .task-item.completed {
-    opacity: 0.6;
-  }
-
-  .checkbox {
-    width: 20px;
-    height: 20px;
-    border: 2px solid var(--border-color);
-    border-radius: 4px;
-    background: transparent;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    margin-top: 2px;
-  }
-
-  .checkbox:hover {
-    border-color: var(--accent-color);
-  }
-
-  .checkbox.checked {
-    background: var(--accent-color);
-    border-color: var(--accent-color);
-    color: white;
-  }
-
-  .checkbox svg {
-    width: 14px;
-    height: 14px;
-  }
-
-  .task-content {
-    flex: 1;
-    min-width: 0;
-    cursor: pointer;
-    background: none;
-    border: none;
-    padding: 0;
-    font: inherit;
-    text-align: left;
-    color: inherit;
-  }
-
-  .task-title {
-    display: block;
-    font-size: 0.9375rem;
-  }
-
-  .completed .task-title {
-    text-decoration: line-through;
-  }
-
-  .task-meta {
-    display: flex;
-    gap: 0.5rem;
-    margin-top: 0.25rem;
-    font-size: 0.75rem;
-  }
-
-  .due-date {
-    color: var(--text-secondary);
-  }
-
-  .due-date.overdue {
-    color: var(--error-color);
-    font-weight: 500;
-  }
-
-  .priority {
-    padding: 0.125rem 0.375rem;
-    border-radius: 3px;
-    font-weight: 500;
-  }
-
-  .priority-high {
-    background: var(--priority-high-bg);
-    color: var(--priority-high-text);
-  }
-
-  .priority-medium {
-    background: var(--priority-medium-bg);
-    color: var(--priority-medium-text);
-  }
-
-  .priority-low {
-    background: var(--priority-low-bg);
-    color: var(--priority-low-text);
-  }
-
-  .recurrence {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    color: var(--text-secondary);
-  }
-
-  .recurrence-icon {
-    width: 12px;
-    height: 12px;
-  }
-
-  .delete-btn {
-    width: 28px;
-    height: 28px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 0;
-    color: var(--text-secondary);
-  }
-
-  .task-item:hover .delete-btn {
-    opacity: 1;
-  }
-
-  .delete-btn:hover {
-    background: var(--bg-hover);
-    color: var(--error-color);
-  }
-
-  .delete-btn svg {
-    width: 18px;
-    height: 18px;
-  }
-
-  /* Mobile touch target improvements */
-  @media (max-width: 768px) {
-    .task-item {
-      padding: 0.5rem;
-    }
-
-    .checkbox {
-      width: 44px;
-      height: 44px;
-      margin-top: 0;
-    }
-
-    .checkbox svg {
-      width: 24px;
-      height: 24px;
-    }
-
-    .delete-btn {
-      width: 44px;
-      height: 44px;
-      opacity: 1; /* Always visible on mobile */
-    }
-
-    .delete-btn svg {
-      width: 24px;
-      height: 24px;
-    }
-  }
-</style>

--- a/src/lib/components/TaskListView.svelte
+++ b/src/lib/components/TaskListView.svelte
@@ -7,9 +7,10 @@
 
   interface Props {
     onEditTask?: (task: Task) => void;
+    onAddTask?: () => void;
   }
 
-  let { onEditTask }: Props = $props();
+  let { onEditTask, onAddTask }: Props = $props();
 
   // Separate completed and incomplete tasks
   const incompleteTasks = $derived(taskStore.tasks.filter(t => !t.completed));
@@ -33,41 +34,63 @@
   const syncListId = $derived(
     listStore.selectedView?.type === 'list' ? listStore.selectedList?.id : null
   );
+
+  // Can add tasks only in list view (not special views like Today/Overdue)
+  const canAddTasks = $derived(listStore.selectedView?.type === 'list');
 </script>
 
-<div class="task-list-view">
-  <header class="list-header">
-    <div class="header-top">
-      <h1>{viewTitle()}</h1>
-      {#if syncListId}
-        <SyncStatus listId={syncListId} />
-      {/if}
+<div class="flex-1 flex flex-col h-full min-h-0 overflow-hidden">
+  <!-- Header (hidden on mobile, shown in mobile header instead) -->
+  <header class="hidden md:block px-6 pt-6 pb-4 border-b border-surface-300-700">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <h1 class="m-0 text-2xl font-semibold">{viewTitle()}</h1>
+        <span class="text-sm text-surface-500">{incompleteTasks.length} tasks</span>
+      </div>
+      <div class="flex items-center gap-3">
+        {#if syncListId}
+          <SyncStatus listId={syncListId} />
+        {/if}
+        {#if canAddTasks && onAddTask}
+          <button
+            class="btn preset-filled-primary-500"
+            onclick={onAddTask}
+          >
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="12" y1="5" x2="12" y2="19"></line>
+              <line x1="5" y1="12" x2="19" y2="12"></line>
+            </svg>
+            Add Task
+          </button>
+        {/if}
+      </div>
     </div>
-    <span class="task-count">{incompleteTasks.length} tasks</span>
   </header>
 
   {#if taskStore.loading}
-    <div class="loading">Loading tasks...</div>
+    <div class="p-8 text-center text-surface-500">Loading tasks...</div>
   {:else if taskStore.error}
-    <div class="error">{taskStore.error}</div>
+    <div class="p-8 text-center text-error-500">{taskStore.error}</div>
   {:else}
-    <div class="tasks-container">
+    <div class="flex-1 overflow-y-auto px-4 py-3 md:px-6 md:py-4 pb-[calc(0.75rem+var(--safe-area-bottom))]">
       {#if incompleteTasks.length === 0 && completedTasks.length === 0}
-        <div class="empty-state">
-          <p>No tasks yet</p>
-          <p class="hint">Add a task to get started</p>
+        <div class="p-8 text-center text-surface-500">
+          <p class="my-1">No tasks yet</p>
+          <p class="my-1 text-sm">Add a task to get started</p>
         </div>
       {:else}
-        <div class="task-section">
+        <div class="flex flex-col">
           {#each incompleteTasks as task (task.id)}
             <TaskItem {task} onEdit={onEditTask} />
           {/each}
         </div>
 
         {#if !hideCompletedSection && completedTasks.length > 0}
-          <details class="completed-section">
-            <summary>Completed ({completedTasks.length})</summary>
-            <div class="task-section">
+          <details class="mt-6 pt-4 border-t border-surface-300-700">
+            <summary class="cursor-pointer text-sm text-surface-500 py-2 select-none hover:text-surface-700 dark:hover:text-surface-300">
+              Completed ({completedTasks.length})
+            </summary>
+            <div class="flex flex-col">
               {#each completedTasks as task (task.id)}
                 <TaskItem {task} onEdit={onEditTask} />
               {/each}
@@ -78,101 +101,3 @@
     </div>
   {/if}
 </div>
-
-<style>
-  .task-list-view {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    min-height: 0;
-    overflow: hidden;
-  }
-
-  .list-header {
-    padding: 1.5rem 1.5rem 1rem;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .header-top {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-  }
-
-  .list-header h1 {
-    margin: 0;
-    font-size: 1.5rem;
-    font-weight: 600;
-  }
-
-  .task-count {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-  }
-
-  .tasks-container {
-    flex: 1;
-    overflow-y: auto;
-    padding: 1rem 1.5rem;
-  }
-
-  .task-section {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .completed-section {
-    margin-top: 1.5rem;
-    border-top: 1px solid var(--border-color);
-    padding-top: 1rem;
-  }
-
-  .completed-section summary {
-    cursor: pointer;
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    padding: 0.5rem 0;
-    user-select: none;
-  }
-
-  .completed-section summary:hover {
-    color: var(--text-primary);
-  }
-
-  .loading,
-  .error,
-  .empty-state {
-    padding: 2rem;
-    text-align: center;
-  }
-
-  .error {
-    color: var(--error-color);
-  }
-
-  .empty-state {
-    color: var(--text-secondary);
-  }
-
-  .empty-state p {
-    margin: 0.25rem 0;
-  }
-
-  .empty-state .hint {
-    font-size: 0.875rem;
-  }
-
-  /* Mobile adjustments */
-  @media (max-width: 768px) {
-    .list-header {
-      display: none; /* Title shown in mobile header */
-    }
-
-    .tasks-container {
-      padding: 0.75rem 1rem;
-      padding-bottom: env(safe-area-inset-bottom, 0.75rem);
-    }
-  }
-</style>

--- a/src/lib/components/ThemeSettings.svelte
+++ b/src/lib/components/ThemeSettings.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { SegmentedControl } from '@skeletonlabs/skeleton-svelte';
+  import { themeStore, AVAILABLE_THEMES, type ThemeMode, type ThemeName } from '$lib/stores/theme.svelte';
+
+  function handleThemeChange(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    themeStore.setTheme(select.value as ThemeName);
+  }
+
+  function handleModeChange(details: { value: string | null }) {
+    if (details.value) {
+      themeStore.setMode(details.value as ThemeMode);
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-6">
+  <div class="flex justify-between items-center">
+    <h2 class="m-0 text-xl font-semibold">Appearance</h2>
+  </div>
+
+  <div class="flex flex-col gap-4">
+    <!-- Theme Selection -->
+    <label class="flex flex-col gap-2">
+      <span class="text-sm font-medium">Theme</span>
+      <select
+        class="input"
+        value={themeStore.theme}
+        onchange={handleThemeChange}
+      >
+        {#each AVAILABLE_THEMES as theme (theme.value)}
+          <option value={theme.value}>{theme.label}</option>
+        {/each}
+      </select>
+    </label>
+
+    <!-- Mode Selection (Light/Dark/System) -->
+    <div class="flex flex-col gap-2">
+      <span class="text-sm font-medium">Mode</span>
+      <SegmentedControl
+        value={themeStore.mode}
+        onValueChange={handleModeChange}
+      >
+        <SegmentedControl.Control class="w-full">
+          <SegmentedControl.Indicator />
+          <SegmentedControl.Item value="light">
+            <SegmentedControl.ItemText>
+              <span class="flex items-center gap-1.5">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 0 0-1.41 0 .996.996 0 0 0 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 0 0-1.41 0 .996.996 0 0 0 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 0 0 0-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 0 0 0-1.41.996.996 0 0 0-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 0 0 0-1.41.996.996 0 0 0-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"/>
+                </svg>
+                Light
+              </span>
+            </SegmentedControl.ItemText>
+            <SegmentedControl.ItemHiddenInput />
+          </SegmentedControl.Item>
+          <SegmentedControl.Item value="dark">
+            <SegmentedControl.ItemText>
+              <span class="flex items-center gap-1.5">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 3a9 9 0 1 0 9 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 0 1-4.4 2.26 5.403 5.403 0 0 1-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/>
+                </svg>
+                Dark
+              </span>
+            </SegmentedControl.ItemText>
+            <SegmentedControl.ItemHiddenInput />
+          </SegmentedControl.Item>
+          <SegmentedControl.Item value="system">
+            <SegmentedControl.ItemText>
+              <span class="flex items-center gap-1.5">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z"/>
+                </svg>
+                System
+              </span>
+            </SegmentedControl.ItemText>
+            <SegmentedControl.ItemHiddenInput />
+          </SegmentedControl.Item>
+        </SegmentedControl.Control>
+      </SegmentedControl>
+      <span class="text-xs text-surface-500">
+        {#if themeStore.mode === 'system'}
+          Currently using {themeStore.resolvedMode} mode based on system preference
+        {/if}
+      </span>
+    </div>
+  </div>
+</div>

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,0 +1,122 @@
+/**
+ * Theme store for theme selection and light/dark mode toggle
+ * with system preference detection and localStorage persistence.
+ */
+
+const THEME_KEY = 'potasko-theme';
+const MODE_KEY = 'potasko-mode';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+// Available Skeleton themes (keep in sync with CSS imports in app.css)
+export const AVAILABLE_THEMES = [
+  { value: 'catppuccin', label: 'Catppuccin' },
+  { value: 'cerberus', label: 'Cerberus' },
+  { value: 'concord', label: 'Concord' },
+  { value: 'crimson', label: 'Crimson' },
+  { value: 'fennec', label: 'Fennec' },
+  { value: 'hamlindigo', label: 'Hamlindigo' },
+  { value: 'legacy', label: 'Legacy' },
+  { value: 'mint', label: 'Mint' },
+  { value: 'modern', label: 'Modern' },
+  { value: 'mona', label: 'Mona' },
+  { value: 'nosh', label: 'Nosh' },
+  { value: 'nouveau', label: 'Nouveau' },
+  { value: 'pine', label: 'Pine' },
+  { value: 'reign', label: 'Reign' },
+  { value: 'rocket', label: 'Rocket' },
+  { value: 'rose', label: 'Rose' },
+  { value: 'sahara', label: 'Sahara' },
+  { value: 'seafoam', label: 'Seafoam' },
+  { value: 'terminus', label: 'Terminus' },
+  { value: 'vintage', label: 'Vintage' },
+  { value: 'vox', label: 'Vox' },
+  { value: 'wintry', label: 'Wintry' },
+] as const;
+
+export type ThemeName = typeof AVAILABLE_THEMES[number]['value'];
+
+const DEFAULT_THEME: ThemeName = 'cerberus';
+
+class ThemeStore {
+  theme = $state<ThemeName>(DEFAULT_THEME);
+  mode = $state<ThemeMode>('system');
+  resolvedMode = $state<'light' | 'dark'>('light');
+  private initialized = false;
+
+  /** Initialize the store - must be called from onMount in a component */
+  init() {
+    if (this.initialized || typeof window === 'undefined') return;
+    this.initialized = true;
+
+    // Load saved preferences
+    const savedTheme = localStorage.getItem(THEME_KEY) as ThemeName | null;
+    if (savedTheme && AVAILABLE_THEMES.some(t => t.value === savedTheme)) {
+      this.theme = savedTheme;
+    }
+
+    const savedMode = localStorage.getItem(MODE_KEY) as ThemeMode | null;
+    if (savedMode && ['light', 'dark', 'system'].includes(savedMode)) {
+      this.mode = savedMode;
+    }
+
+    // Apply theme and mode
+    this.applyTheme();
+    this.updateResolvedMode();
+
+    // Listen for system preference changes
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    mediaQuery.addEventListener('change', () => {
+      if (this.mode === 'system') {
+        this.updateResolvedMode();
+      }
+    });
+  }
+
+  private updateResolvedMode() {
+    if (typeof window === 'undefined') return;
+
+    let resolved: 'light' | 'dark';
+    if (this.mode === 'system') {
+      resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    } else {
+      resolved = this.mode;
+    }
+
+    this.resolvedMode = resolved;
+    this.applyMode(resolved);
+  }
+
+  private applyMode(mode: 'light' | 'dark') {
+    if (typeof document === 'undefined') return;
+    // Use .dark class (Tailwind selector strategy)
+    if (mode === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }
+
+  private applyTheme() {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute('data-theme', this.theme);
+  }
+
+  setTheme(theme: ThemeName) {
+    this.theme = theme;
+    localStorage.setItem(THEME_KEY, theme);
+    this.applyTheme();
+  }
+
+  setMode(mode: ThemeMode) {
+    this.mode = mode;
+    localStorage.setItem(MODE_KEY, mode);
+    this.updateResolvedMode();
+  }
+
+  get isDark() {
+    return this.resolvedMode === 'dark';
+  }
+}
+
+export const themeStore = new ThemeStore();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,14 +4,16 @@
   import { listStore } from '$lib/stores/lists.svelte';
   import { taskStore } from '$lib/stores/tasks.svelte';
   import { syncStore } from '$lib/stores/sync.svelte';
+  import { themeStore } from '$lib/stores/theme.svelte';
   import Sidebar from '$lib/components/Sidebar.svelte';
   import TaskListView from '$lib/components/TaskListView.svelte';
   import TaskForm from '$lib/components/TaskForm.svelte';
+  import ThemeSettings from '$lib/components/ThemeSettings.svelte';
   import AccountList from '$lib/components/AccountList.svelte';
 
   let editingTask = $state<Task | null>(null);
   let showSettings = $state(false);
-  let showMobileForm = $state(false);
+  let showTaskForm = $state(false);
 
   // Mobile responsiveness state
   const MOBILE_BREAKPOINT = 768;
@@ -49,6 +51,7 @@
 
   // Load lists on mount
   onMount(() => {
+    themeStore.init();
     listStore.load();
     checkMobile();
     window.addEventListener('resize', checkMobile);
@@ -85,38 +88,40 @@
 
   function handleEditTask(task: Task) {
     editingTask = task;
-    if (isMobile) {
-      showMobileForm = true;
-    }
+    showTaskForm = true;
   }
 
-  function handleCloseEdit() {
+  function handleCloseForm() {
     editingTask = null;
-    showMobileForm = false;
+    showTaskForm = false;
   }
 
   function handleToggleSettings() {
     showSettings = !showSettings;
   }
 
-  function handleFabClick() {
+  function handleAddTask() {
     editingTask = null;
-    showMobileForm = true;
+    showTaskForm = true;
   }
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-<div class="app-layout" class:mobile={isMobile}>
+<div class="h-full flex flex-col md:flex-row overflow-hidden">
+  <!-- Mobile header -->
   {#if isMobile}
-    <header class="mobile-header">
-      <button class="hamburger-btn" onclick={toggleSidebar} aria-label="Toggle menu">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <header class="flex items-center gap-3 px-4 py-3 pt-[calc(0.75rem+var(--safe-area-top))] bg-surface-100-900 border-b border-surface-300-700">
+      <button
+        class="btn-icon preset-tonal"
+        onclick={toggleSidebar}
+        aria-label="Toggle menu"
+      >
+        <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="3" y1="12" x2="21" y2="12"></line>
           <line x1="3" y1="6" x2="21" y2="6"></line>
           <line x1="3" y1="18" x2="21" y2="18"></line>
         </svg>
       </button>
-      <h1>{currentViewTitle()}</h1>
+      <h1 class="m-0 text-lg font-semibold">{currentViewTitle()}</h1>
     </header>
   {/if}
 
@@ -128,213 +133,94 @@
     onClose={closeSidebar}
   />
 
+  <!-- Mobile backdrop -->
   {#if isMobile && sidebarOpen}
-    <div class="backdrop visible" onclick={closeSidebar}></div>
+    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+    <div
+      class="fixed inset-0 bg-black/50 z-[99] transition-opacity"
+      onclick={closeSidebar}
+    ></div>
   {/if}
 
-  <main class="main-content">
+  <main class="flex-1 flex flex-col min-w-0 min-h-0">
     {#if showSettings}
-      <div class="settings-panel">
-        <AccountList />
+      <div class="flex-1 p-6 md:p-8 overflow-y-auto bg-surface-50-950">
+        <div class="max-w-2xl mx-auto flex flex-col gap-8">
+          <ThemeSettings />
+          <hr class="border-surface-300-700" />
+          <AccountList />
+        </div>
       </div>
     {:else if listStore.selectedView}
-      <TaskListView onEditTask={handleEditTask} />
-      {#if canAddTasks}
-        {#if !isMobile}
-          <!-- Desktop: inline form -->
-          {#key editingTask?.id}
-            <TaskForm task={editingTask} onClose={handleCloseEdit} />
-          {/key}
-        {/if}
-      {/if}
+      <TaskListView onEditTask={handleEditTask} onAddTask={handleAddTask} />
     {:else if listStore.loading}
-      <div class="loading-state">Loading...</div>
+      <div class="flex-1 flex flex-col items-center justify-center text-surface-500">Loading...</div>
     {:else}
-      <div class="empty-state">
-        <p>No lists yet</p>
-        <p>Create a list to get started</p>
+      <div class="flex-1 flex flex-col items-center justify-center text-surface-500">
+        <p class="my-1">No lists yet</p>
+        <p class="my-1">Create a list to get started</p>
       </div>
     {/if}
   </main>
 
-  <!-- Mobile: FAB and modal form -->
-  {#if isMobile && canAddTasks && !showSettings}
-    {#if showMobileForm}
+  <!-- Task form modal (both mobile and desktop) -->
+  {#if showTaskForm && canAddTasks && !showSettings}
+    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+    <div
+      class="fixed inset-0 bg-black/50 z-[200] flex animate-fadeIn
+             {isMobile ? 'items-end' : 'items-center justify-center p-4'}"
+      onclick={handleCloseForm}
+    >
       <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-      <div class="form-modal-backdrop" onclick={handleCloseEdit}>
-        <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-        <div class="form-modal" onclick={(e) => e.stopPropagation()}>
-          <div class="form-modal-handle"></div>
-          <div class="form-modal-header">
-            <span>{editingTask ? 'Edit Task' : 'New Task'}</span>
-            <button class="form-modal-close" onclick={handleCloseEdit} aria-label="Close">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18"></line>
-                <line x1="6" y1="6" x2="18" y2="18"></line>
-              </svg>
-            </button>
-          </div>
-          {#key editingTask?.id}
-            <TaskForm task={editingTask} onClose={handleCloseEdit} />
-          {/key}
+      <div
+        class="bg-surface-50-950 overflow-y-auto
+               {isMobile
+                 ? 'w-full rounded-t-2xl animate-slideUp max-h-[90vh]'
+                 : 'w-full max-w-lg rounded-xl shadow-xl animate-scaleIn'}"
+        onclick={(e) => e.stopPropagation()}
+      >
+        {#if isMobile}
+          <div class="w-9 h-1 bg-surface-300-700 rounded-full mx-auto mt-2"></div>
+        {/if}
+        <div class="flex items-center justify-between px-4 py-3 {isMobile ? '' : 'border-b border-surface-300-700'}">
+          <span class="font-semibold text-lg">{editingTask ? 'Edit Task' : 'New Task'}</span>
+          <button
+            class="btn-icon preset-tonal"
+            onclick={handleCloseForm}
+            aria-label="Close"
+          >
+            <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
         </div>
+        {#key editingTask?.id}
+          <TaskForm task={editingTask} onClose={handleCloseForm} />
+        {/key}
       </div>
-    {:else}
-      <button class="fab" onclick={handleFabClick} aria-label="Add task">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="12" y1="5" x2="12" y2="19"></line>
-          <line x1="5" y1="12" x2="19" y2="12"></line>
-        </svg>
-      </button>
-    {/if}
+    </div>
+  {/if}
+
+  <!-- Mobile FAB -->
+  {#if isMobile && canAddTasks && !showSettings && !showTaskForm}
+    <button
+      class="fixed bottom-[calc(1.5rem+var(--safe-area-bottom))] right-6 w-14 h-14 rounded-full
+             bg-primary-500 text-white border-none cursor-pointer
+             flex items-center justify-center shadow-lg z-[100]
+             transition-transform hover:scale-105 active:scale-95"
+      onclick={handleAddTask}
+      aria-label="Add task"
+    >
+      <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="12" y1="5" x2="12" y2="19"></line>
+        <line x1="5" y1="12" x2="19" y2="12"></line>
+      </svg>
+    </button>
   {/if}
 </div>
 
 <style>
-  .app-layout {
-    display: flex;
-    height: 100%;
-    overflow: hidden;
-  }
-
-  .app-layout.mobile {
-    flex-direction: column;
-  }
-
-  .main-content {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    min-height: 0;
-  }
-
-  .loading-state,
-  .empty-state {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-secondary);
-  }
-
-  .empty-state p {
-    margin: 0.25rem 0;
-  }
-
-  .settings-panel {
-    flex: 1;
-    padding: 1.5rem;
-    overflow-y: auto;
-    background: var(--bg-primary);
-  }
-
-  @media (max-width: 768px) {
-    .settings-panel {
-      padding: 1rem;
-    }
-  }
-
-  /* Floating Action Button */
-  .fab {
-    position: fixed;
-    bottom: calc(1.5rem + env(safe-area-inset-bottom, 0));
-    right: 1.5rem;
-    width: 56px;
-    height: 56px;
-    border-radius: 50%;
-    background: var(--accent-color);
-    color: white;
-    border: none;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-    z-index: 100;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-  }
-
-  .fab:hover {
-    transform: scale(1.05);
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
-  }
-
-  .fab:active {
-    transform: scale(0.95);
-  }
-
-  .fab svg {
-    width: 24px;
-    height: 24px;
-  }
-
-  /* Mobile form modal */
-  .form-modal-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 200;
-    display: flex;
-    align-items: flex-end;
-    animation: fadeIn 0.2s ease;
-  }
-
-  .form-modal {
-    width: 100%;
-    background: var(--bg-primary);
-    border-radius: 16px 16px 0 0;
-    animation: slideUp 0.3s ease;
-    max-height: 90vh;
-    overflow-y: auto;
-  }
-
-  .form-modal-handle {
-    width: 36px;
-    height: 4px;
-    background: var(--border-color);
-    border-radius: 2px;
-    margin: 8px auto;
-  }
-
-  .form-modal-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 1rem 0.5rem;
-    font-weight: 600;
-  }
-
-  .form-modal-close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-secondary);
-    border-radius: 50%;
-  }
-
-  .form-modal-close:hover {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-
-  .form-modal-close svg {
-    width: 20px;
-    height: 20px;
-  }
-
-  /* Remove TaskForm border when in modal */
-  .form-modal :global(.task-form) {
-    border-top: none;
-    padding-top: 0;
-  }
-
   @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }
@@ -343,5 +229,22 @@
   @keyframes slideUp {
     from { transform: translateY(100%); }
     to { transform: translateY(0); }
+  }
+
+  @keyframes scaleIn {
+    from { opacity: 0; transform: scale(0.95); }
+    to { opacity: 1; transform: scale(1); }
+  }
+
+  .animate-fadeIn {
+    animation: fadeIn 0.2s ease;
+  }
+
+  .animate-slideUp {
+    animation: slideUp 0.3s ease;
+  }
+
+  .animate-scaleIn {
+    animation: scaleIn 0.2s ease;
   }
 </style>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,12 @@
 import { defineConfig } from "vite";
 import { sveltekit } from "@sveltejs/kit/vite";
+import tailwindcss from "@tailwindcss/vite";
 
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-  plugins: [sveltekit()],
+  plugins: [sveltekit(), tailwindcss()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //


### PR DESCRIPTION
## Summary

- Migrate entire frontend from custom CSS to Skeleton UI components and Tailwind CSS 4
- Add theme selection with 22 available Skeleton themes
- Add light/dark/system mode toggle with system preference detection and localStorage persistence
- Unify task add/edit UX to use modals on both desktop and mobile

## Changes

### Dependencies
- Added `@skeletonlabs/skeleton` and `@skeletonlabs/skeleton-svelte` (v4)
- Added `tailwindcss@4` with `@tailwindcss/vite` plugin

### New Files
- `src/lib/stores/theme.svelte.ts` - Theme and mode store with persistence
- `src/lib/components/ThemeSettings.svelte` - Theme preferences UI in settings

### Modified Files
- `src/app.css` - Replaced 177 lines of custom CSS with Skeleton imports
- `src/app.html` - Added `data-theme="cerberus"` attribute
- `vite.config.js` - Added Tailwind CSS plugin
- All 10 component files migrated to Skeleton patterns:
  - Buttons: `btn preset-filled-*`, `btn preset-outlined`, `btn-icon preset-tonal`
  - Forms: `input` class for text/select/textarea
  - Badges: `badge preset-filled-*` for priority indicators
  - Cards: `card` utilities for sections
  - Dark mode: `.dark` class (Tailwind selector strategy)

### UI/UX Improvements
- Desktop now uses centered modal dialog for task add/edit (same as mobile bottom sheet)
- Theme dropdown in Settings with all 22 Skeleton themes
- Segmented control for light/dark/system mode selection
- Proper system preference detection with media query listener

## Test plan

- [ ] Build check: `pnpm build` succeeds
- [ ] Desktop: Create/edit/delete lists and tasks
- [ ] Desktop: Priority badges display correctly (red/yellow/blue)
- [ ] Desktop: Sidebar navigation works
- [ ] Desktop: Dark mode toggle works (light/dark/system)
- [ ] Desktop: Theme selection persists across reload
- [ ] Mobile (<768px): Hamburger menu opens drawer
- [ ] Mobile: FAB appears and opens bottom sheet modal
- [ ] Mobile: Touch targets are adequately sized
- [ ] CalDAV sync: Accounts can be added/edited/deleted
- [ ] Accessibility: Keyboard navigation (Tab, Enter, Escape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)