### PR TITLE
fix: add safe-area-inset-bottom padding to sidebar footer

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -537,6 +537,7 @@
   .sidebar-footer {
     margin-top: auto;
     border-top: 1px solid var(--app-color-border);
+    padding-bottom: env(safe-area-inset-bottom, 0);
   }
 
   .sync-indicator {


### PR DESCRIPTION
The settings button was being hidden under the gesture navigation bar
on Android phones. Adding padding-bottom using env(safe-area-inset-bottom)
ensures the footer clears the system navigation bar.

https://claude.ai/code/session_014aKori7KHGigsRnnENQQZr